### PR TITLE
Fix #select_or_else for Left value.

### DIFF
--- a/lib/fear/either.rb
+++ b/lib/fear/either.rb
@@ -143,8 +143,8 @@ module Fear
   #   @example
   #     Right(12).select_or_else(-1, &:even?)       #=> Right(12)
   #     Right(7).select_or_else(-1, &:even?)        #=> Left(-1)
-  #     Left(12).select_or_else(-1, &:even?)        #=> Left(-1)
-  #     Left(12).select_or_else(-> { -1 }, &:even?) #=> Left(-1)
+  #     Left(12).select_or_else(-1, &:even?)        #=> Left(12)
+  #     Left(12).select_or_else(-> { -1 }, &:even?) #=> Left(12)
   #
   # @!method select(&predicate)
   #   Returns +Left+ of value if the given predicate

--- a/lib/fear/left.rb
+++ b/lib/fear/left.rb
@@ -15,10 +15,9 @@ module Fear
     end
     alias failure? left?
 
-    # @param default [Proc, any]
     # @return [Either]
-    def select_or_else(default)
-      Left.new(Utils.return_or_call_proc(default))
+    def select_or_else(*)
+      self
     end
 
     # @return [Left]

--- a/lib/fear/version.rb
+++ b/lib/fear/version.rb
@@ -1,3 +1,3 @@
 module Fear
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end

--- a/spec/fear/left_spec.rb
+++ b/spec/fear/left_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe Fear::Left do
     context 'proc default' do
       let(:default) { -> { -1 } }
 
-      it 'returns Left of evaluated default' do
-        is_expected.to eq(described_class.new(-1))
+      it 'returns itself' do
+        is_expected.to eq(left)
       end
     end
 
     context 'default' do
       let(:default) { -1 }
 
-      it 'return Left of default' do
-        is_expected.to eq(described_class.new(-1))
+      it 'returns itself' do
+        is_expected.to eq(left)
       end
     end
   end


### PR DESCRIPTION
It should always return left.

```ruby
Right(12).select_or_else(-1, &:even?)       #=> Right(12)
Right(7).select_or_else(-1, &:even?)        #=> Left(-1)
Left(12).select_or_else(-1, &:even?)        #=> Left(12)
Left(12).select_or_else(-> { -1 }, &:even?) #=> Left(12)
```