### PR TITLE
Adds missing closing brace to Try's example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ include Fear::Try::Mixin
 dividend = Try { Integer(params[:dividend]) }
 divisor = Try { Integer(params[:divisor]) }
 
-result = dividend.flat_map { |x| divisor.map { |y| x / y }
+result = dividend.flat_map { |x| divisor.map { |y| x / y } }
 
 if result.success?
   puts "Result of #{dividend.get} / #{divisor.get} is: #{result.get}"

--- a/lib/fear/try.rb
+++ b/lib/fear/try.rb
@@ -13,7 +13,7 @@ module Fear
   #
   #   dividend = Try { Integer(params[:dividend]) }
   #   divisor = Try { Integer(params[:divisor]) }
-  #   problem = dividend.flat_map { |x| divisor.map { |y| x / y }
+  #   problem = dividend.flat_map { |x| divisor.map { |y| x / y } }
   #
   #   if problem.success?
   #     puts "Result of #{dividend.get} / #{divisor.get} is: #{problem.get}"


### PR DESCRIPTION
The readme file has a tiny error in one of the examples, a missing closing brace in the example for `Try`. This should fix it.

**Edit:** Found the same error in the doc comment, fixed it there, too.