### PR TITLE
Implement `Either#or_else` and `Option#or_else`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.6.0
+
+* Added `Either#or_else` and `Option#or_else`. `Try#or_else` may accept only block ([@bolshakov][])
+  
+[@bolshakov]: https://github.com/bolshakov

--- a/lib/fear/either.rb
+++ b/lib/fear/either.rb
@@ -45,6 +45,14 @@ module Fear
   #       Right(42).get_or_else(12)         #=> 42
   #       Left('undefined').get_or_else(12) #=> 12
   #
+  # @!method or_else(&alternative)
+  #   Returns this +Right+ or the given alternative if this is a +Left+.
+  #   @return [Either]
+  #   @example
+  #     Right(42).or_else { Right(21) }           #=> Right(42)
+  #     Left('unknown').or_else { Right(21) }     #=> Right(21)
+  #     Left('unknown').or_else { Left('empty') } #=> Left('empty')
+  #
   # @!method include?(other_value)
   #   Returns +true+ if +Right+ has an element that is equal
   #   (as determined by +==+) to +other_value+, +false+ otherwise.

--- a/lib/fear/failure.rb
+++ b/lib/fear/failure.rb
@@ -27,8 +27,8 @@ module Fear
     end
 
     # @return [Try] of calling block
-    def or_else
-      Success.new(yield)
+    def or_else(*args)
+      super
     rescue => error
       Failure.new(error)
     end

--- a/lib/fear/option.rb
+++ b/lib/fear/option.rb
@@ -42,6 +42,14 @@ module Fear
   #       Some(42).get_or_else(12)  #=> 42
   #       None().get_or_else(12)    #=> 12
   #
+  # @!method or_else(&alternative)
+  #   Returns this +Some+ or the given alternative if this is a +None+.
+  #   @return [Option]
+  #   @example
+  #     Some(42).or_else { Some(21) } #=> Some(42)
+  #     None().or_else { Some(21) }   #=> Some(21)
+  #     None().or_else { None() }     #=> None()
+  #
   # @!method include?(other_value)
   #   Returns +true+ if it has an element that is equal
   #   (as determined by +==+) to +other_value+, +false+ otherwise.

--- a/lib/fear/right_biased.rb
+++ b/lib/fear/right_biased.rb
@@ -11,6 +11,15 @@ module Fear
         super
       end
 
+      # Returns this `RightBiased::Right` or the given alternative if
+      # this is a `RightBiased::Left`.
+      def or_else(*args, &block)
+        Utils.assert_arg_or_block!('or_else', *args, &block)
+        super.tap do |result|
+          Utils.assert_type!(result, left_class, right_class)
+        end
+      end
+
       def flat_map
         super.tap do |result|
           Utils.assert_type!(result, left_class, right_class)
@@ -41,6 +50,11 @@ module Fear
       #
       def get_or_else(*_args)
         value
+      end
+
+      # @return [self]
+      def or_else
+        self
       end
 
       # @param [any]
@@ -110,6 +124,13 @@ module Fear
       #
       def get_or_else(*args)
         args.fetch(0) { yield }
+      end
+
+      # @!method get_or_else(&alternative)
+      #   @return [RightBiased] result of evaluating a block.
+      #
+      def or_else(*_args)
+        yield
       end
 
       # @param [any]

--- a/lib/fear/try.rb
+++ b/lib/fear/try.rb
@@ -144,14 +144,13 @@ module Fear
   #     Success(42).get                 #=> 42
   #     Failure(ArgumentError.new).get  #=> ArgumentError: ArgumentError
   #
-  # @!method or_else(&default)
-  #   Returns this +Try+ if it's a +Success+ or the given default
-  #   argument if this is a +Failure+.
+  # @!method or_else(&alternative)
+  #   Returns this +Try+ if it's a +Success+ or the given alternative if this is a +Failure+.
   #   @return [Try]
   #   @example
-  #     Success(42).or_else { -1 }                 #=> Success(42)
-  #     Failure(ArgumentError.new).or_else { -1 }  #=> Success(-1)
-  #     Failure(ArgumentError.new).or_else { 1/0 } #=> Failure(ZeroDivisionError.new('divided by 0'))
+  #     Success(42).or_else { Success(-1) }                 #=> Success(42)
+  #     Failure(ArgumentError.new).or_else { Success(-1) }  #=> Success(-1)
+  #     Failure(ArgumentError.new).or_else { Try { 1/0 } }  #=> Failure(ZeroDivisionError.new('divided by 0'))
   #
   # @!method flatten
   #   Transforms a nested +Try+, ie, a +Success+ of +Success+,

--- a/spec/fear/failure_spec.rb
+++ b/spec/fear/failure_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Fear::Failure do
 
   describe '#or_else' do
     context 'default does not fail' do
-      subject { failure.or_else { 'value' } }
+      subject { failure.or_else { Fear::Success.new('value') } }
       it { is_expected.to eq(Fear::Success.new('value')) }
     end
 

--- a/spec/fear/left_spec.rb
+++ b/spec/fear/left_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe Fear::Left do
     end
   end
 
+  describe '#or_else' do
+    subject { left.or_else { alternative } }
+    let(:alternative) { Left(42) }
+
+    it 'returns alternative' do
+      is_expected.to eq(alternative)
+    end
+  end
+
   describe '#select' do
     subject do
       left.select { |v| v == 'value' }

--- a/spec/fear/none_spec.rb
+++ b/spec/fear/none_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Fear::None do
     it { is_expected.to eq(nil) }
   end
 
+  describe '#or_else' do
+    subject { none.or_else { alternative } }
+    let(:alternative) { Some(42) }
+
+    it 'returns alternative' do
+      is_expected.to eq(alternative)
+    end
+  end
+
   describe '#empty?' do
     subject { none.empty? }
     it { is_expected.to eq(true) }

--- a/spec/fear/right_biased/right.rb
+++ b/spec/fear/right_biased/right.rb
@@ -41,6 +41,16 @@ RSpec.shared_examples Fear::RightBiased::Right do
     end
   end
 
+  describe '#or_else' do
+    it 'does not call block' do
+      expect { |probe| right.or_else(&probe) }.not_to yield_control
+    end
+
+    it 'returns the same object' do
+      expect(right.or_else { 42 }).to eql(right)
+    end
+  end
+
   describe '#map' do
     subject { right.map(&:length) }
 


### PR DESCRIPTION
```ruby
Right(42).or_else { Right(21) }           #=> Right(42)
Left('unknown').or_else { Right(21) }     #=> Right(21)
Left('unknown').or_else { Left('empty') } #=> Left('empty')
```

```ruby
Some(42).or_else { Some(21) } #=> Some(42)
None().or_else { Some(21) }   #=> Some(21)
None().or_else { None() }     #=> None()
```

`Try#or_else` does not accept argument anymore. Only block variat acceptable:

```ruby
Success(42).or_else { Success(-1) }                 #=> Success(42)
Failure(ArgumentError.new).or_else { Success(-1) }  #=> Success(-1)
Failure(ArgumentError.new).or_else { Try { 1/0 } }  #=> Failure(ZeroDivisionError.new('divided by 0'))
```

Accepting an argument may lead to unexpected errors:

```ruby
Failure(ArgumentError.new).or_else(1/0) #=> fails with ZeroDivisionError
```

Since `Try` monad intended to be used to avoid exceptions, I decided to get rid of that syntax. Sorry for breaking change :( 