### PR TITLE
Better errors for types assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0
+
+* Better errors for types assertions ([@bolshakov][])
+
 ## 0.6.0
 
 * Added `Either#or_else` and `Option#or_else`. `Try#or_else` may accept only block ([@bolshakov][])

--- a/lib/fear/utils.rb
+++ b/lib/fear/utils.rb
@@ -11,7 +11,7 @@ module Fear
 
     def assert_type!(value, *types)
       if types.none? { |type| value.is_a?(type) }
-        fail TypeError, "expected `#{value}` to be of #{types.join(', ')} class"
+        fail TypeError, "expected `#{value.inspect}` to be of #{types.join(', ')} class"
       end
     end
 

--- a/lib/fear/version.rb
+++ b/lib/fear/version.rb
@@ -1,3 +1,3 @@
 module Fear
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
Before:

```ruby
Option(42).flat_map { nil } #=> TypeError: expected `` to be of Fear::None, Fear::Some class
```

After:

```ruby
Option(42).flat_map { nil } #=> TypeError: expected `nil` to be of Fear::None, Fear::Some class
```