### PR TITLE
[WIP] Implement pattern matching using Qo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 # gem 'codeclimate-test-reporter', group: :test, require: nil
+
+gem 'qo', github: 'baweaver/qo', ref: '603701051'

--- a/fear.gemspec
+++ b/fear.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'dry-equalizer', '<= 0.2.1'
+  spec.add_runtime_dependency 'qo', '0.99.0'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'

--- a/gemfiles/dry_equalizer_0.1.0.gemfile
+++ b/gemfiles/dry_equalizer_0.1.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "qo", github: "baweaver/qo", branch: "baweaver/exhaustive_match", ref: "60362f1b2e8cb3ccbc1bf80dfb67faf20b1d2c51"
 gem "dry-equalizer", "0.1.0"
 
 gemspec path: "../"

--- a/gemfiles/dry_equalizer_0.1.0.gemfile.lock
+++ b/gemfiles/dry_equalizer_0.1.0.gemfile.lock
@@ -1,12 +1,23 @@
+GIT
+  remote: git://github.com/baweaver/qo.git
+  revision: 60362f1b2e8cb3ccbc1bf80dfb67faf20b1d2c51
+  ref: 60362f1b2e8cb3ccbc1bf80dfb67faf20b1d2c51
+  branch: baweaver/exhaustive_match
+  specs:
+    qo (0.99.1)
+      any (= 0.1.0)
+
 PATH
   remote: ..
   specs:
     fear (0.10.0)
       dry-equalizer (<= 0.2.1)
+      qo (>= 0.99.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    any (0.1.0)
     appraisal (2.2.0)
       bundler
       rake
@@ -58,6 +69,7 @@ DEPENDENCIES
   bundler
   dry-equalizer (= 0.1.0)
   fear!
+  qo!
   rake (~> 10.0)
   rspec (~> 3.1)
   rubocop (= 0.65.0)

--- a/gemfiles/dry_equalizer_0.2.1.gemfile
+++ b/gemfiles/dry_equalizer_0.2.1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "qo", github: "baweaver/qo", branch: "baweaver/exhaustive_match", ref: "60362f1b2e8cb3ccbc1bf80dfb67faf20b1d2c51"
 gem "dry-equalizer", "0.2.1"
 
 gemspec path: "../"

--- a/gemfiles/dry_equalizer_0.2.1.gemfile.lock
+++ b/gemfiles/dry_equalizer_0.2.1.gemfile.lock
@@ -1,12 +1,23 @@
+GIT
+  remote: git://github.com/baweaver/qo.git
+  revision: 60362f1b2e8cb3ccbc1bf80dfb67faf20b1d2c51
+  ref: 60362f1b2e8cb3ccbc1bf80dfb67faf20b1d2c51
+  branch: baweaver/exhaustive_match
+  specs:
+    qo (0.99.1)
+      any (= 0.1.0)
+
 PATH
   remote: ..
   specs:
     fear (0.10.0)
       dry-equalizer (<= 0.2.1)
+      qo (>= 0.99.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    any (0.1.0)
     appraisal (2.2.0)
       bundler
       rake
@@ -58,6 +69,7 @@ DEPENDENCIES
   bundler
   dry-equalizer (= 0.2.1)
   fear!
+  qo!
   rake (~> 10.0)
   rspec (~> 3.1)
   rubocop (= 0.65.0)

--- a/lib/fear.rb
+++ b/lib/fear.rb
@@ -5,11 +5,13 @@ module Fear
   Error = Class.new(StandardError)
   IllegalStateException = Class.new(Error)
   NoSuchElementError = Class.new(Error)
+  MatchError = Class.new(Error)
 
   autoload :Done, 'fear/done'
   autoload :For, 'fear/for'
   autoload :RightBiased, 'fear/right_biased'
   autoload :Utils, 'fear/utils'
+  autoload :ExhaustivePatternMatch, 'fear/exhaustive_pattern_match'
 
   autoload :Option, 'fear/option'
   autoload :Some, 'fear/some'

--- a/lib/fear/either.rb
+++ b/lib/fear/either.rb
@@ -1,3 +1,5 @@
+require 'fear/either/pattern_match'
+
 module Fear
   # Represents a value of one of two possible types (a disjoint union.)
   # An instance of +Either+ is either an instance of +Left+ or +Right+.
@@ -19,12 +21,11 @@ module Fear
   #     Left(in)
   #   end
   #
-  #   puts(
-  #     result.reduce(
-  #       -> (x) { "You passed me the String: #{x}" },
-  #       -> (x) { "You passed me the Int: #{x}, which I will increment. #{x} + 1 = #{x+1}" }
-  #     )
-  #   )
+  #   message = result.match do |m|
+  #     m.left { |x| "You passed me the String: #{x}" },
+  #     m.right { |x| "You passed me the Int: #{x}, which I will increment. #{x} + 1 = #{x+1}" }
+  #   end
+  #   puts message
   #
   # Either is right-biased, which means that +Right+ is assumed to be the default case to
   # operate on. If it is +Left+, operations like +#map+, +#flat_map+, ... return the +Left+ value
@@ -227,9 +228,39 @@ module Fear
   #     Right("daisy").join_left        #=> Right("daisy")
   #     Right(Left("daisy")).join_left  #=> Right(Left("daisy"))
   #
+  # @!method match(&patterns)
+  #   Pattern match against the +Either+
+  #   @yieldparam matcher [Fear::Either::PatternMatch]
+  #   @raise [Fear::MatchError] if nothing matched
+  #   @see https://github.com/baweaver/qo for full API
+  #
+  #   @example #right and #left
+  #     Right(42).match do |m|
+  #       m.right { |x| x * 2 }
+  #       m.left { |x| x.to_i * 2 }
+  #     end #=> 84
+  #
+  #   @example #right with condition
+  #     Right(41).match do |m|
+  #       m.right(:even?) { |x| x / 2 }
+  #       m.right(:odd?) { |x| x * 2 }
+  #     end #=> 82
+  #
+  #   @example not exhaustive match
+  #     Right(42).match do |m|
+  #       m.right(:odd?) { |x| x * 2 }
+  #     end #=> raises Fear::MatchError
+  #
+  #   @example else branch
+  #     Right(42).match do |m|
+  #       m.right(:odd?) { |x| x * 2 }
+  #       m.else { nil }
+  #     end #=> nil
+  #
   # @see https://github.com/scala/scala/blob/2.12.x/src/library/scala/util/Either.scala
   #
   module Either
+    include PatternMatch.mixin
     include Dry::Equalizer(:value)
 
     # @private

--- a/lib/fear/either/pattern_match.rb
+++ b/lib/fear/either/pattern_match.rb
@@ -1,0 +1,30 @@
+require 'qo'
+
+module Fear
+  module Either
+    RightBranch = Qo.create_branch(
+      name: 'right',
+      precondition: :right?,
+      extractor: ->(e) { e.send(:value) },
+    )
+
+    private_constant :RightBranch
+
+    LeftBranch = Qo.create_branch(
+      name: 'left',
+      precondition: :left?,
+      extractor: ->(e) { e.send(:value) },
+    )
+
+    private_constant :LeftBranch
+
+    PatternMatch = Qo.create_pattern_match(
+      branches: [
+        RightBranch,
+        LeftBranch,
+      ],
+    ).prepend(ExhaustivePatternMatch)
+
+    private_constant :PatternMatch
+  end
+end

--- a/lib/fear/exhaustive_pattern_match.rb
+++ b/lib/fear/exhaustive_pattern_match.rb
@@ -1,0 +1,26 @@
+require 'qo'
+
+module Fear
+  # Should be prepended to Qo::PatternMatchers::PatternMatch
+  # @see Qo::PatternMatchers::PatternMatch
+  module ExhaustivePatternMatch
+    EXHAUSTIVE_PATTERN_MATCH_ERROR = <<-ERROR.freeze
+      Pattern match is not exhaustive.
+
+      You've got this error because pattern match is not exhaustive. The
+      simplest way to resolve this error is to add `else` branch. For example:
+
+      monad.match do |m|
+        # ...
+        m.else { 'not matched' }
+      end
+    ERROR
+
+    def initialize(*)
+      super
+      @default ||= self.else { raise MatchError, EXHAUSTIVE_PATTERN_MATCH_ERROR }
+    end
+  end
+
+  private_constant :ExhaustivePatternMatch
+end

--- a/lib/fear/failure.rb
+++ b/lib/fear/failure.rb
@@ -67,16 +67,5 @@ module Fear
     def to_either
       Left.new(exception)
     end
-
-    # Used in case statement
-    # @param other [any]
-    # @return [Boolean]
-    def ===(other)
-      if other.is_a?(Failure)
-        exception === other.exception
-      else
-        super
-      end
-    end
   end
 end

--- a/lib/fear/left.rb
+++ b/lib/fear/left.rb
@@ -53,16 +53,5 @@ module Fear
         Utils.assert_type!(v, Either)
       end
     end
-
-    # Used in case statement
-    # @param other [any]
-    # @return [Boolean]
-    def ===(other)
-      if other.is_a?(Left)
-        value === other.value
-      else
-        super
-      end
-    end
   end
 end

--- a/lib/fear/option.rb
+++ b/lib/fear/option.rb
@@ -1,3 +1,5 @@
+require 'fear/option/pattern_match'
+
 module Fear
   # Represents optional values. Instances of +Option+
   # are either an instance of +Some+ or the object +None+.
@@ -11,13 +13,11 @@ module Fear
   # having to check for the existence of a value.
   #
   # @example A less-idiomatic way to use +Option+ values is via pattern matching
-  #   name = Option(params[:name])
-  #   case name
-  #   when Some
-  #     puts name.strip.upcase
-  #   when None
-  #     puts 'No name value'
+  #   message = Option(params[:name]).match do |m|
+  #     m.some { |name| name.strip.upcase }
+  #     m.none { 'No name value' }
   #   end
+  #   puts message
   #
   # @example or manually checking for non emptiness
   #   name = Option(params[:name])
@@ -145,9 +145,42 @@ module Fear
   #     Some(42).empty? #=> false
   #     None().empty?   #=> true
   #
+  # @!method match(&patterns)
+  #   Pattern match against the +Option+
+  #   @yieldparam matcher [Fear::Option::PatternMatch]
+  #   @raise [Fear::MatchError] if nothing matched
+  #   @see https://github.com/baweaver/qo for full API
+  #
+  #   @example #some and #none
+  #     Some(42).match do |m|
+  #       m.some { |x| x * 2 }
+  #       m.none { 'none' }
+  #     end #=> 84
+  #
+  #   @example #some with condition
+  #     Some(41).match do |m|
+  #       m.some(:even?) { |x| x / 2 }
+  #       m.some(:odd?) { |x| x * 2 }
+  #       m.none { 'none' }
+  #     end #=> 82
+  #
+  #   @example not exhaustive match
+  #     Some(42).match do |m|
+  #       m.some(:odd?) { |x| x * 2 }
+  #       m.none { 'none' }
+  #     end #=> raises Fear::MatchError
+  #
+  #   @example else branch
+  #     Some(42).match do |m|
+  #       m.some(:odd?) { |x| x * 2 }
+  #       m.else { nil }
+  #     end #=> nil
+  #
   # @see https://github.com/scala/scala/blob/2.11.x/src/library/scala/Option.scala
   #
   module Option
+    include PatternMatch.mixin
+
     # @private
     def left_class
       None

--- a/lib/fear/option/pattern_match.rb
+++ b/lib/fear/option/pattern_match.rb
@@ -1,0 +1,29 @@
+require 'qo'
+
+module Fear
+  module Option
+    SomeBranch = Qo.create_branch(
+      name: 'some',
+      precondition: ->(v) { !v.empty? },
+      extractor: :get,
+    )
+
+    private_constant :SomeBranch
+
+    NoneBranch = Qo.create_branch(
+      name: 'none',
+      precondition: ->(v) { v.empty? },
+    )
+
+    private_constant :NoneBranch
+
+    PatternMatch = Qo.create_pattern_match(
+      branches: [
+        SomeBranch,
+        NoneBranch,
+      ],
+    ).prepend(ExhaustivePatternMatch)
+
+    private_constant :PatternMatch
+  end
+end

--- a/lib/fear/right_biased.rb
+++ b/lib/fear/right_biased.rb
@@ -99,17 +99,6 @@ module Fear
       def any?
         yield(value)
       end
-
-      # Used in case statement
-      # @param other [any]
-      # @return [Boolean]
-      def ===(other)
-        if other.is_a?(right_class)
-          value === other.value
-        else
-          super
-        end
-      end
     end
 
     module Left

--- a/lib/fear/try.rb
+++ b/lib/fear/try.rb
@@ -1,3 +1,5 @@
+require 'fear/try/pattern_match'
+
 module Fear
   # The +Try+ represents a computation that may either result
   # in an exception, or return a successfully computed value. Instances of +Try+,
@@ -210,10 +212,43 @@ module Fear
   #     Success(42).to_either                #=> Right(42)
   #     Failure(ArgumentError.new).to_either #=> Left(ArgumentError.new)
   #
+  # @!method match(&patterns)
+  #   Pattern match against the +Try+
+  #   @yieldparam matcher [Fear::Try::PatternMatch]
+  #   @raise [Fear::MatchError] if nothing matched
+  #   @see https://github.com/baweaver/qo for full API
+  #
+  #   @example #success and #failurre
+  #     Success(42).match do |m|
+  #       m.success { |x| x * 2 }
+  #       m.failure { |error| raise error }
+  #     end #=> 84
+  #
+  #   @example #some with condition
+  #     Success(41).match do |m|
+  #       m.success(:even?) { |x| x / 2 }
+  #       m.success(:odd?) { |x| x * 2 }
+  #       m.failure { |error| raise error }
+  #     end #=> 82
+  #
+  #   @example not exhaustive match
+  #     Some(42).match do |m|
+  #       m.success(:odd?) { |x| x * 2 }
+  #       m.failure { |error| raise error }
+  #     end #=> raises Fear::MatchError
+  #
+  #   @example else branch
+  #     Some(42).match do |m|
+  #       m.success(:odd?) { |x| x * 2 }
+  #       m.else { nil }
+  #     end #=> nil
+  #
   # @author based on Twitter's original implementation.
   # @see https://github.com/scala/scala/blob/2.11.x/src/library/scala/util/Try.scala
   #
   module Try
+    include PatternMatch.mixin
+
     # @private
     def left_class
       Failure

--- a/lib/fear/try/pattern_match.rb
+++ b/lib/fear/try/pattern_match.rb
@@ -1,0 +1,30 @@
+require 'qo'
+
+module Fear
+  module Try
+    SuccessBranch = Qo.create_branch(
+      name: 'success',
+      precondition: :success?,
+      extractor: :get,
+    )
+
+    private_constant :SuccessBranch
+
+    FailureBranch = Qo.create_branch(
+      name: 'failure',
+      precondition: :failure?,
+      extractor: :exception,
+    )
+
+    private_constant :FailureBranch
+
+    PatternMatch = Qo.create_pattern_match(
+      branches: [
+        SuccessBranch,
+        FailureBranch,
+      ],
+    ).prepend(ExhaustivePatternMatch)
+
+    private_constant :PatternMatch
+  end
+end

--- a/spec/fear/failure_spec.rb
+++ b/spec/fear/failure_spec.rb
@@ -115,4 +115,41 @@ RSpec.describe Fear::Failure do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#match' do
+    context 'matched' do
+      subject do
+        failure.match do |m|
+          m.failure(->(e) { e.message == 'error' }) { |v| "Failure: #{v}" }
+          m.success { |v| "Success: #{v}" }
+        end
+      end
+
+      it { is_expected.to eq('Failure: error') }
+    end
+
+    context 'nothing matched and no else given' do
+      subject do
+        proc do
+          failure.match do |m|
+            m.failure(->(e) { e.message != 'error' }) { |v| "Failure: #{v}" }
+            m.success { |v| "Success: #{v}" }
+          end
+        end
+      end
+
+      it { is_expected.to raise_error(Fear::MatchError) }
+    end
+
+    context 'nothing matched and else given' do
+      subject do
+        failure.match do |m|
+          m.success { |v| "Success: #{v}" }
+          m.else { :default }
+        end
+      end
+
+      it { is_expected.to eq(:default) }
+    end
+  end
 end

--- a/spec/fear/failure_spec.rb
+++ b/spec/fear/failure_spec.rb
@@ -92,30 +92,6 @@ RSpec.describe Fear::Failure do
     it { is_expected.to eq(Left(exception)) }
   end
 
-  describe '#===' do
-    subject { match === failure }
-
-    context 'matches erectly' do
-      let(:match) { Failure(exception) }
-      it { is_expected.to eq(true) }
-    end
-
-    context 'value does not match' do
-      let(:match) { Failure(ArgumentError.new) }
-      it { is_expected.to eq(false) }
-    end
-
-    context 'matches by class' do
-      let(:match) { Failure(RuntimeError) }
-      it { is_expected.to eq(true) }
-    end
-
-    context 'does not matches by class' do
-      let(:match) { Failure(ArgumentError) }
-      it { is_expected.to eq(false) }
-    end
-  end
-
   describe '#match' do
     context 'matched' do
       subject do

--- a/spec/fear/left_spec.rb
+++ b/spec/fear/left_spec.rb
@@ -118,30 +118,6 @@ RSpec.describe Fear::Left do
     end
   end
 
-  describe '#===' do
-    subject { match === left }
-
-    context 'matches erectly' do
-      let(:match) { Left('value') }
-      it { is_expected.to eq(true) }
-    end
-
-    context 'value does not match' do
-      let(:match) { Left('error') }
-      it { is_expected.to eq(false) }
-    end
-
-    context 'matches by class' do
-      let(:match) { Left(String) }
-      it { is_expected.to eq(true) }
-    end
-
-    context 'does not matches by class' do
-      let(:match) { Left(Integer) }
-      it { is_expected.to eq(false) }
-    end
-  end
-
   describe '#match' do
     context 'matched' do
       subject do

--- a/spec/fear/left_spec.rb
+++ b/spec/fear/left_spec.rb
@@ -141,4 +141,41 @@ RSpec.describe Fear::Left do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#match' do
+    context 'matched' do
+      subject do
+        left.match do |m|
+          m.left(->(x) { x == 'value' }) { |v| "Left: #{v}" }
+          m.right { |v| "Right: #{v}" }
+        end
+      end
+
+      it { is_expected.to eq('Left: value') }
+    end
+
+    context 'nothing matched and no else given' do
+      subject do
+        proc do
+          left.match do |m|
+            m.left(->(x) { x != 'value' }) { |v| "Left: #{v}" }
+            m.right { |v| "Right: #{v}" }
+          end
+        end
+      end
+
+      it { is_expected.to raise_error(Fear::MatchError) }
+    end
+
+    context 'nothing matched and else given' do
+      subject do
+        left.match do |m|
+          m.right { |v| "Right: #{v}" }
+          m.else { :default }
+        end
+      end
+
+      it { is_expected.to eq(:default) }
+    end
+  end
 end

--- a/spec/fear/none_spec.rb
+++ b/spec/fear/none_spec.rb
@@ -46,4 +46,40 @@ RSpec.describe Fear::None do
       is_expected.to eq(None())
     end
   end
+
+  describe '#match' do
+    context 'matched' do
+      subject do
+        none.match do |m|
+          m.some { |x| x * 2 }
+          m.none { 'noop' }
+        end
+      end
+
+      it { is_expected.to eq('noop') }
+    end
+
+    context 'nothing matched and no else given' do
+      subject do
+        proc do
+          none.match do |m|
+            m.some { |x| x * 2 }
+          end
+        end
+      end
+
+      it { is_expected.to raise_error(Fear::MatchError) }
+    end
+
+    context 'nothing matched and else given' do
+      subject do
+        none.match do |m|
+          m.some { |x| x * 2 }
+          m.else { :default }
+        end
+      end
+
+      it { is_expected.to eq(:default) }
+    end
+  end
 end

--- a/spec/fear/right_biased/left.rb
+++ b/spec/fear/right_biased/left.rb
@@ -80,13 +80,4 @@ RSpec.shared_examples Fear::RightBiased::Left do
     subject { left.any? { |v| v == 'value' } }
     it { is_expected.to eq(false) }
   end
-
-  describe '#===' do
-    subject { match === left }
-
-    context 'the same object' do
-      let(:match) { left }
-      it { is_expected.to eq(true) }
-    end
-  end
 end

--- a/spec/fear/right_biased/right.rb
+++ b/spec/fear/right_biased/right.rb
@@ -116,33 +116,4 @@ RSpec.shared_examples Fear::RightBiased::Right do
       it { is_expected.to eq(false) }
     end
   end
-
-  describe '#===' do
-    subject { match === right }
-
-    context 'matches erectly' do
-      let(:match) { described_class.new('value') }
-      it { is_expected.to eq(true) }
-    end
-
-    context 'the same object' do
-      let(:match) { right }
-      it { is_expected.to eq(true) }
-    end
-
-    context 'value does not match' do
-      let(:match) { described_class.new('error') }
-      it { is_expected.to eq(false) }
-    end
-
-    context 'matches by class' do
-      let(:match) { described_class.new(String) }
-      it { is_expected.to eq(true) }
-    end
-
-    context 'does not matches by class' do
-      let(:match) { described_class.new(Integer) }
-      it { is_expected.to eq(false) }
-    end
-  end
 end

--- a/spec/fear/right_spec.rb
+++ b/spec/fear/right_spec.rb
@@ -114,4 +114,41 @@ RSpec.describe Fear::Right do
       it { is_expected.to eq(either) }
     end
   end
+
+  describe '#match' do
+    context 'matched' do
+      subject do
+        right.match do |m|
+          m.right(->(x) { x == 'value' }) { |v| "Right: #{v}" }
+          m.left { |v| "Left: #{v}" }
+        end
+      end
+
+      it { is_expected.to eq('Right: value') }
+    end
+
+    context 'nothing matched and no else given' do
+      subject do
+        proc do
+          right.match do |m|
+            m.right(->(x) { x != 'value' }) { |v| "Right: #{v}" }
+            m.left { |v| "Left: #{v}" }
+          end
+        end
+      end
+
+      it { is_expected.to raise_error(Fear::MatchError) }
+    end
+
+    context 'nothing matched and else given' do
+      subject do
+        right.match do |m|
+          m.left { |v| "Left: #{v}" }
+          m.else { :default }
+        end
+      end
+
+      it { is_expected.to eq(:default) }
+    end
+  end
 end

--- a/spec/fear/some_spec.rb
+++ b/spec/fear/some_spec.rb
@@ -49,4 +49,41 @@ RSpec.describe Fear::Some do
     subject { some.empty? }
     it { is_expected.to eq(false) }
   end
+
+  describe '#match' do
+    context 'matched' do
+      subject do
+        some.match do |m|
+          m.some(->(x) { x > 2 }) { |x| x * 2 }
+          m.none { 'noop' }
+        end
+      end
+
+      it { is_expected.to eq(84) }
+    end
+
+    context 'nothing matched and no else given' do
+      subject do
+        proc do
+          some.match do |m|
+            m.some(->(x) { x < 2 }) { |x| x * 2 }
+            m.none { 'noop' }
+          end
+        end
+      end
+
+      it { is_expected.to raise_error(Fear::MatchError) }
+    end
+
+    context 'nothing matched and else given' do
+      subject do
+        some.match do |m|
+          m.none { |x| x * 2 }
+          m.else { :default }
+        end
+      end
+
+      it { is_expected.to eq(:default) }
+    end
+  end
 end

--- a/spec/fear/success_spec.rb
+++ b/spec/fear/success_spec.rb
@@ -90,4 +90,41 @@ RSpec.describe Fear::Success do
     subject { success.to_either }
     it { is_expected.to eq(Right('value')) }
   end
+
+  describe '#match' do
+    context 'matched' do
+      subject do
+        success.match do |m|
+          m.success(->(x) { x == 'value' }) { |v| "Success: #{v}" }
+          m.failure { |v| "Failure: #{v}" }
+        end
+      end
+
+      it { is_expected.to eq('Success: value') }
+    end
+
+    context 'nothing matched and no else given' do
+      subject do
+        proc do
+          success.match do |m|
+            m.success(->(x) { x != 'value' }) { |v| "Success: #{v}" }
+            m.failure { |v| "Failure: #{v}" }
+          end
+        end
+      end
+
+      it { is_expected.to raise_error(Fear::MatchError) }
+    end
+
+    context 'nothing matched and else given' do
+      subject do
+        success.match do |m|
+          m.failure { |v| "failure: #{v}" }
+          m.else { :default }
+        end
+      end
+
+      it { is_expected.to eq(:default) }
+    end
+  end
 end


### PR DESCRIPTION
See https://github.com/baweaver/qo

```ruby
Some(42).match do |m|
  m.some { |x| x * 2 }
  m.none { 'none' }
end #=> 84
```

you can pass a conditions to #some method

```ruby
Some(41).match do |m|
  m.some(:even?) { |x| x / 2 }
  m.some(:odd?, ->(v) { v > 0 }) { |x| x * 2 }
  m.none { 'none' }
end #=> 82
```

it raises `Fear::MatchError` if pattern match is not exhaustive

```ruby
Some(42).match do |m|
  m.some(:odd?) { |x| x * 2 }
  m.none { 'none' }
end #=> raises Fear::MatchError
```

to avoid exception, you can pass `#else` branch

```ruby
Some(42).match do |m|
  m.some(:odd?) { |x| x * 2 }
  m.else { 'nothing' }
end #=> nothing
```


Waiting the following PR to be released:

* https://github.com/baweaver/qo/pull/24
* https://github.com/baweaver/qo/pull/25