### PR TITLE
Implement Fear::PartialFunction

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
 Naming/MethodName:
   Enabled: false
 
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 
@@ -29,9 +32,14 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
+Style/NumericPredicate:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - Rakefile
+    - fear.gemspec
 
 Metrics/LineLength:
   Max: 120

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,331 @@
 require 'bundler/gem_tasks'
+require 'benchmark/ips'
+require_relative 'lib/fear'
+require 'any'
+
+namespace :perf do
+  namespace :and_then do
+    task :call_or_else_proc do
+      class NotOptimized < Fear::PartialFunction::AndThen
+        def call_or_else(arg)
+          if partial_function.defined_at?(arg)
+            function.call(partial_function.call(arg))
+          else
+            yield arg
+          end
+        end
+      end
+
+      class OptimizedScalish < Fear::PartialFunction::AndThen
+        FALLBACK = ->(*) { FALLBACK }
+        class << self
+          def fallback_occurred(x)
+            x.__id__ == FALLBACK.__id__
+          end
+        end
+
+        def call_or_else(arg)
+          result = partial_function.call_or_else(arg, &FALLBACK)
+          if OptimizedScalish.fallback_occurred(result)
+            yield arg
+          else
+            function.call(result)
+          end
+        end
+      end
+
+      class OptimizedRubish < Fear::PartialFunction::AndThen
+        TAG = Object.new.freeze
+
+        def call_or_else(arg)
+          catch(TAG) do
+            result = partial_function.call_or_else(arg) { throw(TAG, yield(arg)) }
+            function.call(result)
+          end
+        end
+      end
+
+      class OptimizedReturn < Fear::PartialFunction::AndThen
+        def call_or_else(arg)
+          result = partial_function.call_or_else(arg) do
+            return yield(arg)
+          end
+          function.call(result)
+        end
+      end
+
+      pf = Fear::PartialFunctionClass.new(->(x) { x.odd? }) { |x| x }
+      default = ->(*) { 'default' }
+      fallback = ->(*) { 'fallback' }
+
+      not_optimized = NotOptimized.new(pf, &default)
+      optimized_scalish = OptimizedScalish.new(pf, &default)
+      optimized_rubish = OptimizedRubish.new(pf, &default)
+      optimized_return = OptimizedReturn.new(pf, &default)
+
+      Benchmark.ips do |x|
+        x.report('AndThen#call_or_else optimized return') do |n|
+          n.times do |t|
+            optimized_return.call_or_else(t, &fallback)
+          end
+        end
+
+        x.report('AndThen#call_or_else not optimized') do |n|
+          n.times do |t|
+            not_optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.compare!
+      end
+
+      Benchmark.ips do |x|
+        x.report('AndThen#call_or_else optimized scalish') do |n|
+          n.times do |t|
+            optimized_scalish.call_or_else(t, &fallback)
+          end
+        end
+
+        x.report('AndThen#call_or_else not optimized') do |n|
+          n.times do |t|
+            not_optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.compare!
+      end
+
+      Benchmark.ips do |x|
+        x.report('AndThen#call_or_else optimized rubish') do |n|
+          n.times do |t|
+            optimized_rubish.call_or_else(t, &fallback)
+          end
+        end
+
+        x.report('AndThen#call_or_else not optimized') do |n|
+          n.times do |t|
+            not_optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.compare!
+      end
+    end
+
+    task :call_or_else_partial_function do
+      class NotOptimized < Fear::PartialFunction::Combined
+        def call_or_else(arg)
+          if f1.defined_at?(arg)
+            f2.call_or_else(f1.call(arg)) do |_|
+              yield arg
+            end
+          else
+            yield arg
+          end
+        end
+      end
+
+      class Optimized < Fear::PartialFunction::Combined
+        def call_or_else(arg)
+          result = f1.call_or_else(arg) { yield arg }
+
+          f2.call_or_else(result) do |_|
+            return yield(arg)
+          end
+        end
+      end
+
+      pf1 = Fear::PartialFunctionClass.new(->(x) { x.even? }) { |x| x }
+      pf2 = Fear::PartialFunctionClass.new(->(x) { x % 3 == 0 }) { |x| x }
+      fallback = ->(*) { 'fallback' }
+
+      optimized = Optimized.new(pf1, pf2)
+      not_optimized = NotOptimized.new(pf1, pf2)
+
+      Benchmark.ips do |x|
+        x.report('Combined#call_or_else optimized') do |n|
+          n.times do |t|
+            optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.report('Combined#call_or_else not optimized') do |n|
+          n.times do |t|
+            not_optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.compare!
+      end
+    end
+
+    task :defined_at_partial_function do
+      class NotOptimized < Fear::PartialFunction::Combined
+        def defined_at?(arg)
+          if f1.defined_at?(arg)
+            f2.defined_at?(f1.call(arg))
+          else
+            false
+          end
+        end
+      end
+
+      class Optimized < Fear::PartialFunction::Combined
+        def defined_at?(arg)
+          result = f1.call_or_else(arg) do
+            return false
+          end
+          f2.defined_at?(result)
+        end
+      end
+
+      pf1 = Fear::PartialFunctionClass.new(->(x) { x.odd? }) { |x| x }
+      pf2 = Fear::PartialFunctionClass.new(->(x) { x.even? }) { |x| x }
+
+      optimized = Optimized.new(pf1, pf2)
+      not_optimized = NotOptimized.new(pf1, pf2)
+
+      Benchmark.ips do |x|
+        x.report('Combined#defined_at? optimized') do |n|
+          n.times do |t|
+            optimized.defined_at?(t)
+          end
+        end
+
+        x.report('Combined#defined_at? not optimized') do |n|
+          n.times do |t|
+            not_optimized.defined_at?(t)
+          end
+        end
+
+        x.compare!
+      end
+    end
+  end
+
+  namespace :or_else do
+    task :call_or_else do
+      class NotOptimized < Fear::PartialFunction::OrElse
+        def call_or_else(arg)
+          if f1.defined_at?(arg)
+            f1.call(arg)
+          elsif f2.defined_at?(arg)
+            f2.call(arg)
+          else
+            yield arg
+          end
+        end
+      end
+
+      class Optimized < Fear::PartialFunction::OrElse
+        def call_or_else(arg, &fallback)
+          f1.call_or_else(arg) do
+            return f2.call_or_else(arg, &fallback)
+          end
+        end
+      end
+
+      pf1 = Fear::PartialFunctionClass.new(->(x) { x.odd? }) { |x| x }
+      pf2 = Fear::PartialFunctionClass.new(->(x) { x.even? }) { |x| x }
+
+      fallback = ->(*) { 'fallback' }
+
+      optimized = Optimized.new(pf1, pf2)
+      not_optimized = NotOptimized.new(pf1, pf2)
+
+      Benchmark.ips do |x|
+        x.report('OrElse#call_or_else optimized') do |n|
+          n.times do |t|
+            optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.report('OrElse#call_or_else not optimized') do |n|
+          n.times do |t|
+            not_optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.compare!
+      end
+    end
+
+    task :or_else do
+      class NotOptimized < Fear::PartialFunction::OrElse
+        def or_else(other)
+          NotOptimized.new(self, other)
+        end
+      end
+
+      class Optimized < Fear::PartialFunction::OrElse
+        def or_else(other)
+          Optimized.new(f1, f2.or_else(other))
+        end
+      end
+
+      pf1 = Fear::PartialFunctionClass.new(->(x) { x.even? }) { |x| x }
+      pf2 = Fear::PartialFunctionClass.new(->(x) { x % 3 == 0 }) { |x| x }
+      pf3 = Fear::PartialFunctionClass.new(->(x) { x % 5 == 0 }) { |x| x }
+
+      fallback = ->(*) { 'fallback' }
+
+      optimized = Optimized.new(pf1, pf2).or_else(pf3)
+      not_optimized = NotOptimized.new(pf1, pf2).or_else(pf3)
+
+      Benchmark.ips do |x|
+        x.report('OrElse#or_else#call_or_else optimized') do |n|
+          n.times do |t|
+            optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.report('OrElse#or_else#call_or_else not optimized') do |n|
+          n.times do |t|
+            not_optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.compare!
+      end
+    end
+
+    task :and_then do
+      class NotOptimized < Fear::PartialFunction::OrElse
+        def and_then(&block)
+          AndThen.new(self, &block)
+        end
+      end
+
+      class Optimized < Fear::PartialFunction::OrElse
+        def and_then(&block)
+          OrElse.new(@f1.and_then(&block), @f2.and_then(&block))
+        end
+      end
+
+      pf1 = Fear::PartialFunctionClass.new(->(x) { x.even? }) { |x| x }
+      pf2 = Fear::PartialFunctionClass.new(->(x) { x % 3 == 0 }) { |x| x }
+
+      block = ->(*) { 'blk' }
+      fallback = ->(*) { 'fallback' }
+
+      optimized = Optimized.new(pf1, pf2).and_then(&block)
+      not_optimized = NotOptimized.new(pf1, pf2).and_then(&block)
+
+      Benchmark.ips do |x|
+        x.report('OrElse#or_else#and_then optimized') do |n|
+          n.times do |t|
+            optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.report('OrElse#or_else#and_then not optimized') do |n|
+          n.times do |t|
+            not_optimized.call_or_else(t, &fallback)
+          end
+        end
+
+        x.compare!
+      end
+    end
+  end
+end

--- a/fear.gemspec
+++ b/fear.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rubocop', '0.65.0'
   spec.add_development_dependency 'rubocop-rspec', '1.32.0'
+  spec.add_development_dependency 'any'
 end

--- a/fear.gemspec
+++ b/fear.gemspec
@@ -26,11 +26,12 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'dry-equalizer', '<= 0.2.1'
 
+  spec.add_development_dependency 'any'
   spec.add_development_dependency 'appraisal'
+  spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rubocop', '0.65.0'
   spec.add_development_dependency 'rubocop-rspec', '1.32.0'
-  spec.add_development_dependency 'any'
 end

--- a/gemfiles/dry_equalizer_0.1.0.gemfile.lock
+++ b/gemfiles/dry_equalizer_0.1.0.gemfile.lock
@@ -7,15 +7,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    any (0.1.0)
     appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
+    benchmark-ips (2.7.2)
     diff-lcs (1.3)
     dry-equalizer (0.1.0)
     jaro_winkler (1.5.2)
-    parallel (1.13.0)
+    parallel (1.14.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
@@ -54,7 +56,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  any
   appraisal
+  benchmark-ips
   bundler
   dry-equalizer (= 0.1.0)
   fear!

--- a/gemfiles/dry_equalizer_0.2.1.gemfile.lock
+++ b/gemfiles/dry_equalizer_0.2.1.gemfile.lock
@@ -7,15 +7,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    any (0.1.0)
     appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
+    benchmark-ips (2.7.2)
     diff-lcs (1.3)
     dry-equalizer (0.2.1)
     jaro_winkler (1.5.2)
-    parallel (1.13.0)
+    parallel (1.14.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
@@ -54,7 +56,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  any
   appraisal
+  benchmark-ips
   bundler
   dry-equalizer (= 0.2.1)
   fear!

--- a/lib/fear.rb
+++ b/lib/fear.rb
@@ -5,6 +5,10 @@ module Fear
   Error = Class.new(StandardError)
   IllegalStateException = Class.new(Error)
   NoSuchElementError = Class.new(Error)
+  MatchError = Class.new(Error)
+
+  autoload :PartialFunction, 'fear/partial_function'
+  autoload :PartialFunctionClass, 'fear/partial_function_class'
 
   autoload :Done, 'fear/done'
   autoload :For, 'fear/for'

--- a/lib/fear/partial_function.rb
+++ b/lib/fear/partial_function.rb
@@ -1,0 +1,148 @@
+module Fear
+  # A partial function is a unary function defined on subset of all possible inputs.
+  # The method +defined_at?+ allows to test dynamically if a arg is in
+  # the domain of the function.
+  #
+  #  Even if +defined_at?+ returns true for given arg, calling +call+ may
+  #  still throw an exception, so the following code is legal:
+  #
+  #  @example
+  #    PartialFunction(->(_) { true }) { 1/0 }
+  #
+  # It is the responsibility of the caller to call +defined_at?+ before
+  # calling +call+, because if +defined_at?+ is false, it is not guaranteed
+  # +call+ will throw an exception to indicate an error condition. If an
+  # exception is not thrown, evaluation may result in an arbitrary arg.
+  #
+  # The main distinction between +PartialFunction+ and +Proc+ is
+  # that the user of a +PartialFunction+ may choose to do something different
+  # with input that is declared to be outside its domain. For example:
+  #
+  # @example
+  #   sample = 1...10
+  #
+  #   is-even = PartialFunction(->(arg) { arg % 2 == 0}) do |arg|
+  #     "#{arg} is even"
+  #   end
+  #
+  #   is_odd = PartialFunction(->(arg) { arg % 2 == 1}) do
+  #     "#{arg} is odd"
+  #   end
+  #
+  #   # The method or_else allows chaining another partial function to handle
+  #   # input outside the declared domain
+  #   numbers = sample.map(is_even.or_else(is_odd).to_proc)
+  #
+  # @see https://github.com/scala/scala/commit/5050915eb620af3aa43d6ddaae6bbb83ad74900d
+  module PartialFunction
+    autoload :OrElse, 'fear/partial_function/or_else'
+    autoload :AndThen, 'fear/partial_function/and_then'
+    autoload :Combined, 'fear/partial_function/combined'
+
+    # @param condition [#call] describes the domain of partial function
+    # @param function [Proc] function definition
+    def initialize(condition, &function)
+      @condition = condition
+      @function = function
+    end
+    attr_reader :condition, :function
+    private :condition
+    private :function
+
+    # Checks if a value is contained in the function's domain.
+    #
+    # @param arg [any]
+    # @return [Boolean]
+    def defined_at?(arg)
+      condition === arg
+    end
+
+    # @param arg [any]
+    # @return [any] Calls this partial function with the given argument when it
+    #   is contained in the function domain.
+    # @raise [MatchError] when this partial function is not defined.
+    def call(arg)
+      if defined_at?(arg)
+        function.call(arg)
+      else
+        raise MatchError, "partial function not defined at: #{arg}"
+      end
+    end
+
+    # Converts this partial function to other
+    #
+    # @return [Proc]
+    def to_proc
+      proc { |arg| call(arg) }
+    end
+
+    # Calls this partial function with the given argument when it is contained in the function domain.
+    # Calls fallback function where this partial function is not defined.
+    #
+    # @note that expression +pf.call_or_else(arg, &fallback)+ is equivalent to
+    #   +pf.defined_at?(arg) ? pf.(arg) : fallback.(arg)+
+    #   except that +call_or_else+ method can be implemented more efficiently to avoid calling +defined_at?+ twice.
+    #
+    # @param arg [any]
+    # @yield [arg] if partial function not defined for this +arg+
+    def call_or_else(arg)
+      if defined_at?(arg)
+        call(arg)
+      else
+        yield arg
+      end
+    end
+
+    # Composes this partial function with a fallback partial function which
+    # gets applied where this partial function is not defined.
+    #
+    # @param other [PartialFunction]
+    # @return [PartialFunction] a partial function which has as domain the union of the domains
+    #   of this partial function and +other+.
+    def or_else(other)
+      OrElse.new(self, other)
+    end
+
+    # @see or_else
+    def |(other)
+      or_else(other)
+    end
+
+    UNDEFINED = Object.new.freeze
+
+    # @overload and_then(other)
+    #   @param other [Proc]
+    #   @return [PartialFunction] a partial function with the same domain as this partial function, which maps
+    #     argument +x+ to +other.(self.call(x))+.
+    # @overload and_then(&other)
+    #   @param other [Proc]
+    #   @return [PartialFunction]
+    #
+    # @note Note that calling +#defined_at?+ on the resulting partial function may call the first
+    #   partial function and execute its side effect. It is highly recommended to call +#call_or_else+
+    #   instead of +#defined_at?+/+#call+ for efficiency.
+    def and_then(other = UNDEFINED, &block)
+      if block_given? ^ (other != UNDEFINED)
+        fun = block || other
+        if fun.is_a?(Fear::PartialFunction)
+          Combined.new(self, fun)
+        else
+          AndThen.new(self, &block)
+        end
+      else
+        raise ArgumentError, 'Fear::PartialFunction#and_then accepts either block or partial function'
+      end
+    end
+
+    # @see and_then
+    def &(other)
+      and_then(other)
+    end
+
+    module Mixin
+      def PartialFunction(condition, &function)
+        PartialFunctionClass.new(condition, &function)
+      end
+    end
+  end
+end

--- a/lib/fear/partial_function/and_then.rb
+++ b/lib/fear/partial_function/and_then.rb
@@ -1,0 +1,40 @@
+module Fear
+  module PartialFunction
+    # @api private
+    class AndThen
+      include PartialFunction
+
+      # @param partial_function [Fear::PartialFunction]
+      # @param function [Proc]
+      def initialize(partial_function, &function)
+        @partial_function = partial_function
+        @function = function
+      end
+
+      # @param arg [any]
+      # @return [any ]
+      def call(arg)
+        @function.call(@partial_function.call(arg))
+      end
+
+      # @param arg [any]
+      # @return [Boolean]
+      def defined_at?(arg)
+        @partial_function.defined_at?(arg)
+      end
+
+      # @param arg [any]
+      # @param fallback [Proc]
+      # @return [any]
+      def call_or_else(arg, &fallback)
+        if @partial_function.defined_at?(arg)
+          @function.call(@partial_function.call(arg))
+        else
+          yield arg
+        end
+      end
+    end
+
+    private_constant :AndThen
+  end
+end

--- a/lib/fear/partial_function/and_then.rb
+++ b/lib/fear/partial_function/and_then.rb
@@ -1,5 +1,6 @@
 module Fear
   module PartialFunction
+    # Composite function produced by +PartialFunction#and_then+ method
     # @api private
     class AndThen
       include PartialFunction
@@ -10,28 +11,35 @@ module Fear
         @partial_function = partial_function
         @function = function
       end
+      # @!attribute partial_function
+      #   @return [Fear::PartialFunction]
+      # @!attribute function
+      #   @return [Proc]
+      attr_reader :partial_function
+      attr_reader :function
+      private :partial_function
+      private :function
 
       # @param arg [any]
       # @return [any ]
       def call(arg)
-        @function.call(@partial_function.call(arg))
+        function.call(partial_function.call(arg))
       end
 
       # @param arg [any]
       # @return [Boolean]
       def defined_at?(arg)
-        @partial_function.defined_at?(arg)
+        partial_function.defined_at?(arg)
       end
 
       # @param arg [any]
-      # @param fallback [Proc]
+      # @yield [arg]
       # @return [any]
-      def call_or_else(arg, &fallback)
-        if @partial_function.defined_at?(arg)
-          @function.call(@partial_function.call(arg))
-        else
-          yield arg
+      def call_or_else(arg)
+        result = partial_function.call_or_else(arg) do
+          return yield(arg)
         end
+        function.call(result)
       end
     end
 

--- a/lib/fear/partial_function/combined.rb
+++ b/lib/fear/partial_function/combined.rb
@@ -1,0 +1,48 @@
+module Fear
+  module PartialFunction
+    # @api private
+    class Combined
+      include PartialFunction
+
+      # @param f1 [Fear::PartialFunction]
+      # @param f2 [Fear::PartialFunction]
+      def initialize(f1, f2)
+        @f1 = f1
+        @f2 = f2
+      end
+
+      # @param arg [any]
+      # @return [any ]
+      def call(arg)
+        @f2.call(@f1.call(arg))
+      end
+
+      # FIXME: optimize calling defined_at on @f1 twise
+      # @param arg [any]
+      # @return [Boolean]
+      def defined_at?(arg)
+        if @f1.defined_at?(arg)
+          @f2.defined_at?(@f1.call(arg))
+        else
+          false
+        end
+      end
+
+      # FIXME: optimize calling defined_at on @f1 twise
+      # @param arg [any]
+      # @param fallback [Proc]
+      # @return [any]
+      def call_or_else(arg)
+        if @f1.defined_at?(arg)
+          @f2.call_or_else(@f1.call(arg)) do |_|
+            yield arg
+          end
+        else
+          yield arg
+        end
+      end
+    end
+
+    private_constant :AndThen
+  end
+end

--- a/lib/fear/partial_function/combined.rb
+++ b/lib/fear/partial_function/combined.rb
@@ -1,5 +1,6 @@
 module Fear
   module PartialFunction
+    # Composite function produced by +PartialFunction#and_then+ method
     # @api private
     class Combined
       include PartialFunction
@@ -10,36 +11,27 @@ module Fear
         @f1 = f1
         @f2 = f2
       end
+      # @!attribute f1
+      #   @return [Fear::PartialFunction]
+      # @!attribute f2
+      #   @return [Fear::PartialFunction]
+      attr_reader :f1, :f2
+      private :f1
+      private :f2
 
       # @param arg [any]
       # @return [any ]
       def call(arg)
-        @f2.call(@f1.call(arg))
+        f2.call(f1.call(arg))
       end
 
-      # FIXME: optimize calling defined_at on @f1 twise
       # @param arg [any]
       # @return [Boolean]
       def defined_at?(arg)
-        if @f1.defined_at?(arg)
-          @f2.defined_at?(@f1.call(arg))
-        else
-          false
+        result = f1.call_or_else(arg) do
+          return false
         end
-      end
-
-      # FIXME: optimize calling defined_at on @f1 twise
-      # @param arg [any]
-      # @param fallback [Proc]
-      # @return [any]
-      def call_or_else(arg)
-        if @f1.defined_at?(arg)
-          @f2.call_or_else(@f1.call(arg)) do |_|
-            yield arg
-          end
-        else
-          yield arg
-        end
+        f2.defined_at?(result)
       end
     end
 

--- a/lib/fear/partial_function/empty.rb
+++ b/lib/fear/partial_function/empty.rb
@@ -1,0 +1,31 @@
+module Fear
+  module PartialFunction
+    EMPTY = Object.new.extend(PartialFunction)
+    EMPTY.instance_eval do
+      def defined_at?(_)
+        false
+      end
+
+      def call(arg)
+        raise MatchError, "partial function not defined at: #{arg}"
+      end
+
+      def call_or_else(arg)
+        yield arg
+      end
+
+      def or_else(other)
+        other
+      end
+
+      def and_then(*)
+        self
+      end
+
+      def to_s
+        'Empty partial function'
+      end
+    end
+    EMPTY.freeze
+  end
+end

--- a/lib/fear/partial_function/guard.rb
+++ b/lib/fear/partial_function/guard.rb
@@ -1,0 +1,60 @@
+module Fear
+  module PartialFunction
+    # @api private
+    class Guard
+      class << self
+        # @param conditions [<#===, Symbol>]
+        # @return [Fear::PartialFunction::Guard]
+        def and(conditions)
+          conditions.inject(Utils::UNDEFINED) do |guard, condition|
+            if guard == Utils::UNDEFINED
+              new(condition)
+            else
+              guard.and(new(condition))
+            end
+          end
+        end
+
+        # @param conditions [<#===, Symbol>]
+        # @return [Fear::PartialFunction::Guard]
+        def or(conditions)
+          conditions.inject(Utils::UNDEFINED) do |acc, condition|
+            if acc == Utils::UNDEFINED
+              new(condition)
+            else
+              acc.or(new(condition))
+            end
+          end
+        end
+      end
+
+      # @param condition [<#===, Symbol>]
+      def initialize(condition)
+        @condition =
+          if condition.is_a?(Symbol)
+            condition.to_proc
+          else
+            condition
+          end
+      end
+
+      # @param other [Fear::PartialFunction::Guard]
+      # @return [Fear::PartialFunction::Guard]
+      def and(other)
+        GuardAnd.new(@condition, other)
+      end
+
+      # @param other [Fear::PartialFunction::Guard]
+      # @return [Fear::PartialFunction::Guard]
+      def or(other)
+        GuardOr.new(@condition, other)
+      end
+
+      # @param arg [any]
+      # @return [Boolean]
+      def ===(arg)
+        @condition === arg
+      end
+    end
+  end
+end

--- a/lib/fear/partial_function/guard_and.rb
+++ b/lib/fear/partial_function/guard_and.rb
@@ -1,0 +1,31 @@
+module Fear
+  module PartialFunction
+    # @api private
+    class GuardAnd < Guard
+      # @param c1 [Fear::PartialFunction::Guard]
+      # @param c2 [Fear::PartialFunction::Guard]
+      def initialize(c1, c2)
+        @c1 = c1
+        @c2 = c2
+      end
+
+      # @param other [Fear::PartialFunction::Guard]
+      # @return [Fear::PartialFunction::Guard]
+      def and(other)
+        GuardAnd.new(self, other)
+      end
+
+      # @param other [Fear::PartialFunction::Guard]
+      # @return [Fear::PartialFunction::Guard]
+      def or(other)
+        GuardOr.new(self, other)
+      end
+
+      # @param arg [any]
+      # @return [Boolean]
+      def ===(arg)
+        (@c1 === arg) && (@c2 === arg)
+      end
+    end
+  end
+end

--- a/lib/fear/partial_function/guard_or.rb
+++ b/lib/fear/partial_function/guard_or.rb
@@ -1,0 +1,31 @@
+module Fear
+  module PartialFunction
+    # @api private
+    class GuardOr < Guard
+      # @param c1 [Fear::PartialFunction::Guard]
+      # @param c2 [Fear::PartialFunction::Guard]
+      def initialize(c1, c2)
+        @c1 = c1
+        @c2 = c2
+      end
+
+      # @param other [Fear::PartialFunction::Guard]
+      # @return [Fear::PartialFunction::Guard]
+      def and(other)
+        GuardAnd.new(self, other)
+      end
+
+      # @param other [Fear::PartialFunction::Guard]
+      # @return [Fear::PartialFunction::Guard]
+      def or(other)
+        GuardOr.new(self, other)
+      end
+
+      # @param arg [any]
+      # @return [Boolean]
+      def ===(arg)
+        (@c1 === arg) || (@c2 === arg)
+      end
+    end
+  end
+end

--- a/lib/fear/partial_function/or_else.rb
+++ b/lib/fear/partial_function/or_else.rb
@@ -1,0 +1,42 @@
+module Fear
+  module PartialFunction
+    # @api private
+    class OrElse
+      include PartialFunction
+
+      # @param f1 [Fear::PartialFunction]
+      # @param f2 [Fear::PartialFunction]
+      def initialize(f1, f2)
+        @f1 = f1
+        @f2 = f2
+      end
+
+      # @param arg [any]
+      # @return [any]
+      def call(arg)
+        @f1.call_or_else(arg, &@f2)
+      end
+
+      # @param arg [any]
+      # @return [Boolean]
+      def defined_at?(arg)
+        @f1.defined_at?(arg) || @f2.defined_at?(arg)
+      end
+
+      # @param arg [any]
+      # @param fallback [Proc]
+      # @return [any]
+      def call_or_else(arg, &fallback)
+        if @f1.defined_at?(arg)
+          @f1.call(arg)
+        elsif @f2.defined_at?(arg)
+          @f2.call(arg)
+        else
+          yield arg
+        end
+      end
+    end
+
+    private_constant :OrElse
+  end
+end

--- a/lib/fear/partial_function/or_else.rb
+++ b/lib/fear/partial_function/or_else.rb
@@ -1,5 +1,6 @@
 module Fear
   module PartialFunction
+    # Composite function produced by +PartialFunction#or_else+ method
     # @api private
     class OrElse
       include PartialFunction
@@ -10,29 +11,49 @@ module Fear
         @f1 = f1
         @f2 = f2
       end
+      # @!attribute f1
+      #   @return [Fear::PartialFunction]
+      # @!attribute f2
+      #   @return [Fear::PartialFunction]
+      attr_reader :f1, :f2
+      private :f1
+      private :f2
 
       # @param arg [any]
       # @return [any]
       def call(arg)
-        @f1.call_or_else(arg, &@f2)
+        f1.call_or_else(arg, &f2)
+      end
+
+      # @param other [Fear::PartialFunction]
+      # @return [Fear::PartialFunction]
+      def or_else(other)
+        OrElse.new(f1, f2.or_else(other))
+      end
+
+      # @see Fear::PartialFunction#and_then
+      def and_then(other = Utils::UNDEFINED, &block)
+        Utils.with_block_or_argument('Fear::PartialFunction::OrElse#and_then', other, block) do |fun|
+          if fun.is_a?(Fear::PartialFunction)
+            Combined.new(self, fun)
+          else
+            OrElse.new(f1.and_then(&fun), f2.and_then(&fun))
+          end
+        end
       end
 
       # @param arg [any]
       # @return [Boolean]
       def defined_at?(arg)
-        @f1.defined_at?(arg) || @f2.defined_at?(arg)
+        f1.defined_at?(arg) || f2.defined_at?(arg)
       end
 
       # @param arg [any]
       # @param fallback [Proc]
       # @return [any]
       def call_or_else(arg, &fallback)
-        if @f1.defined_at?(arg)
-          @f1.call(arg)
-        elsif @f2.defined_at?(arg)
-          @f2.call(arg)
-        else
-          yield arg
+        f1.call_or_else(arg) do
+          return f2.call_or_else(arg, &fallback)
         end
       end
     end

--- a/lib/fear/partial_function_class.rb
+++ b/lib/fear/partial_function_class.rb
@@ -2,6 +2,24 @@ module Fear
   # @api private
   class PartialFunctionClass
     include PartialFunction
+
+    # @param arg [any]
+    # @return [any] Calls this partial function with the given argument when it
+    #   is contained in the function domain.
+    # @raise [MatchError] when this partial function is not defined.
+    def call(arg)
+      call_or_else(arg, &PartialFunction::EMPTY)
+    end
+
+    # @param arg [any]
+    # @yield [arg] if function not defined
+    def call_or_else(arg)
+      if defined_at?(arg)
+        function.call(arg)
+      else
+        yield arg
+      end
+    end
   end
 
   private_constant :PartialFunctionClass

--- a/lib/fear/partial_function_class.rb
+++ b/lib/fear/partial_function_class.rb
@@ -1,0 +1,8 @@
+module Fear
+  # @api private
+  class PartialFunctionClass
+    include PartialFunction
+  end
+
+  private_constant :PartialFunctionClass
+end

--- a/lib/fear/utils.rb
+++ b/lib/fear/utils.rb
@@ -1,10 +1,20 @@
 module Fear
   # @private
   module Utils
+    UNDEFINED = Object.new.freeze
+
     class << self
       def assert_arg_or_block!(method_name, *args)
         unless block_given? ^ !args.empty?
           raise ArgumentError, "##{method_name} accepts either one argument or block"
+        end
+      end
+
+      def with_block_or_argument(method_name, arg = UNDEFINED, block = nil)
+        if (!block.nil?) ^ (arg != UNDEFINED)
+          yield(block || arg)
+        else
+          raise ArgumentError, "#{method_name} accepts either block or partial function"
         end
       end
 

--- a/spec/fear/guard_spec.rb
+++ b/spec/fear/guard_spec.rb
@@ -1,0 +1,92 @@
+RSpec.describe Fear::PartialFunction::Guard do
+  context 'Class' do
+    context 'match' do
+      subject { Fear::PartialFunction::Guard.new(Integer) === 4 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'not match' do
+      subject { Fear::PartialFunction::Guard.new(Integer) === '4' }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  context 'Symbol' do
+    context 'match' do
+      subject { Fear::PartialFunction::Guard.new(:even?) === 4 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'not match' do
+      subject { Fear::PartialFunction::Guard.new(:even?) === 3 }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  context 'Proc' do
+    context 'match' do
+      subject { Fear::PartialFunction::Guard.new(->(x) { x.even? }) === 4 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'not match' do
+      subject { Fear::PartialFunction::Guard.new(->(x) { x.even? }) === 3 }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe '.and' do
+    let(:guard) { Fear::PartialFunction::Guard.and([Integer, :even?, ->(x) { x.even? }]) }
+
+    context 'match' do
+      subject { guard === 4 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'not match' do
+      subject { guard === 3 }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'short circuit' do
+      let(:guard) { Fear::PartialFunction::Guard.and([first, second, third]) }
+      let(:first) { ->(_) { false } }
+      let(:second) { ->(_) { raise } }
+      let(:third) { ->(_) { raise } }
+
+      it 'does not call the second and the third' do
+        expect { guard === 4 }.not_to raise_error
+      end
+    end
+  end
+
+  describe '.or' do
+    let(:guard) { Fear::PartialFunction::Guard.or(['F', Integer]) }
+
+    context 'match second' do
+      subject { guard === 4 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'match first' do
+      subject { guard === 'F' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'not match' do
+      subject { guard === 'A&' }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/fear/partial_function/empty_spec.rb
+++ b/spec/fear/partial_function/empty_spec.rb
@@ -1,0 +1,40 @@
+require 'any'
+
+RSpec.describe Fear::PartialFunction::EMPTY do
+  include Fear::PartialFunction::Mixin
+
+  describe '#defined?' do
+    subject { described_class.defined_at?(42) }
+
+    it { is_expected.to be(false) }
+  end
+
+  describe '#call' do
+    subject { -> { described_class.call(42) } }
+
+    it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 42') }
+  end
+
+  describe '#call_or_else' do
+    subject { described_class.call_or_else(42, &default) }
+    let(:default) { ->(x) { "default: #{x}" } }
+
+    it { is_expected.to eq('default: 42') }
+  end
+
+  describe '#and_then' do
+    subject { described_class.and_then { |_x| 'then' } }
+
+    it { is_expected.to eq(described_class) }
+  end
+
+  describe '#or_else' do
+    subject { described_class.or_else(other) }
+
+    let(:other) { PartialFunction(Any) { 'other' } }
+
+    it { is_expected.to eq(other) }
+  end
+
+  it { is_expected.to be_kind_of(Fear::PartialFunction) }
+end

--- a/spec/fear/partial_function_and_then_spec.rb
+++ b/spec/fear/partial_function_and_then_spec.rb
@@ -1,0 +1,147 @@
+RSpec.describe Fear::PartialFunction, '#and_then' do
+  include Fear::PartialFunction::Mixin
+
+  context 'proc' do
+    subject(:pf_and_f) { partial_function.and_then(&function) }
+
+    let(:partial_function) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "pf: #{x}" } }
+    let(:function) { ->(x) { "f: #{x}" } }
+
+    describe '#defined_at?' do
+      context 'defined' do
+        subject { pf_and_f.defined_at?(4) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'not defined' do
+        subject { pf_and_f.defined_at?(3) }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#call' do
+      context 'defined' do
+        subject { pf_and_f.call(4) }
+
+        it { is_expected.to eq('f: pf: 4') }
+      end
+
+      context 'not defined' do
+        subject { -> { pf_and_f.call(3) } }
+
+        it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 3') }
+      end
+    end
+
+    describe '#call_or_else' do
+      let(:fallback) { ->(x) { "fallback: #{x}" } }
+
+      context 'defined' do
+        subject { pf_and_f.call_or_else(4, &fallback) }
+
+        it { is_expected.to eq('f: pf: 4') }
+      end
+
+      context 'not defined' do
+        subject { pf_and_f.call_or_else(3, &fallback) }
+
+        it { is_expected.to eq('fallback: 3') }
+      end
+    end
+  end
+
+  context 'partial function' do
+    subject(:first_and_then_second) { first.and_then(second) }
+
+    describe '#defined_at?' do
+      context 'first defined, second defined on result of first' do
+        subject { first_and_then_second.defined_at?(6) }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'first defined, second not defined on result of first' do
+        subject { first_and_then_second.defined_at?(4) }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'first not defined' do
+        subject { first_and_then_second.defined_at?(3) }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}" } }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#call' do
+      context 'first defined, second defined on result of first' do
+        subject { first_and_then_second.call(6) }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
+
+        it { is_expected.to eq(1) }
+      end
+
+      context 'first defined, second not defined on result of first' do
+        subject { -> { first_and_then_second.call(4) } }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
+
+        it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 2') }
+      end
+
+      context 'first not defined' do
+        subject { -> { first_and_then_second.call(3) } }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}" } }
+
+        it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 3') }
+      end
+    end
+
+    describe '#call_or_else' do
+      let(:fallback) { ->(x) { "fallback: #{x}" } }
+
+      context 'first defined, second defined on result of first' do
+        subject { first_and_then_second.call_or_else(6, &fallback) }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
+
+        it { is_expected.to eq(1) }
+      end
+
+      context 'first defined, second not defined on result of first' do
+        subject { first_and_then_second.call_or_else(4, &fallback) }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
+
+        it { is_expected.to eq('fallback: 4') }
+      end
+
+      context 'first not defined' do
+        subject { first_and_then_second.call_or_else(3, &fallback) }
+
+        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
+        let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}" } }
+
+        it { is_expected.to eq('fallback: 3') }
+      end
+    end
+  end
+end

--- a/spec/fear/partial_function_and_then_spec.rb
+++ b/spec/fear/partial_function_and_then_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
   context 'proc' do
     subject(:pf_and_f) { partial_function.and_then(&function) }
 
-    let(:partial_function) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "pf: #{x}" } }
+    let(:partial_function) { PartialFunction(->(x) { x.even? }) { |x| "pf: #{x}" } }
     let(:function) { ->(x) { "f: #{x}" } }
 
     describe '#defined_at?' do
@@ -59,7 +59,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first defined, second defined on result of first' do
         subject { first_and_then_second.defined_at?(6) }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| x / 2 } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
 
         it { is_expected.to eq(true) }
@@ -68,7 +68,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first defined, second not defined on result of first' do
         subject { first_and_then_second.defined_at?(4) }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| x / 2 } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
 
         it { is_expected.to eq(false) }
@@ -77,7 +77,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first not defined' do
         subject { first_and_then_second.defined_at?(3) }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| "first: #{x}" } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}" } }
 
         it { is_expected.to eq(false) }
@@ -88,7 +88,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first defined, second defined on result of first' do
         subject { first_and_then_second.call(6) }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| x / 2 } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
 
         it { is_expected.to eq(1) }
@@ -97,7 +97,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first defined, second not defined on result of first' do
         subject { -> { first_and_then_second.call(4) } }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| x / 2 } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
 
         it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 2') }
@@ -106,7 +106,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first not defined' do
         subject { -> { first_and_then_second.call(3) } }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| "first: #{x}" } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}" } }
 
         it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 3') }
@@ -119,7 +119,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first defined, second defined on result of first' do
         subject { first_and_then_second.call_or_else(6, &fallback) }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| x / 2 } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
 
         it { is_expected.to eq(1) }
@@ -128,7 +128,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first defined, second not defined on result of first' do
         subject { first_and_then_second.call_or_else(4, &fallback) }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| x / 2 } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| x / 2 } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| x / 3 } }
 
         it { is_expected.to eq('fallback: 4') }
@@ -137,7 +137,7 @@ RSpec.describe Fear::PartialFunction, '#and_then' do
       context 'first not defined' do
         subject { first_and_then_second.call_or_else(3, &fallback) }
 
-        let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
+        let(:first) { PartialFunction(->(x) { x.even? }) { |x| "first: #{x}" } }
         let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}" } }
 
         it { is_expected.to eq('fallback: 3') }

--- a/spec/fear/partial_function_composition_spec.rb
+++ b/spec/fear/partial_function_composition_spec.rb
@@ -4,7 +4,7 @@ require 'any'
 RSpec.describe Fear::PartialFunction do
   include Fear::PartialFunction::Mixin
 
-  let(:fallback_fun) { ->(_) { 'fallback'} }
+  let(:fallback_fun) { ->(_) { 'fallback' } }
   let(:pass_all) { PartialFunction(Any) { |x| x } }
   let(:pass_short) { PartialFunction(->(x) { x.length < 5 }) { |x| x } }
   let(:pass_pass) { PartialFunction(->(x) { x.include?('pass') }) { |x| x } }
@@ -17,44 +17,44 @@ RSpec.describe Fear::PartialFunction do
   let(:short_and_then_pass) { pass_short & pass_pass }
 
   it '#and_then' do
-    expect(all_and_then_short.call_or_else("pass", &fallback_fun)).to eq('pass')
-    expect(short_and_then_all.call_or_else("pass", &fallback_fun)).to eq("pass")
-    expect(all_and_then_short.defined_at?("pass")).to eq(true)
-    expect(short_and_then_all.defined_at?("pass")).to eq(true)
+    expect(all_and_then_short.call_or_else('pass', &fallback_fun)).to eq('pass')
+    expect(short_and_then_all.call_or_else('pass', &fallback_fun)).to eq('pass')
+    expect(all_and_then_short.defined_at?('pass')).to eq(true)
+    expect(short_and_then_all.defined_at?('pass')).to eq(true)
 
-    expect(all_and_then_pass.call_or_else("pass", &fallback_fun)).to eq("pass")
-    expect(pass_and_then_all.call_or_else("pass", &fallback_fun)).to eq("pass")
-    expect(all_and_then_pass.defined_at?("pass")).to eq(true)
-    expect(pass_and_then_all.defined_at?("pass")).to eq(true)
+    expect(all_and_then_pass.call_or_else('pass', &fallback_fun)).to eq('pass')
+    expect(pass_and_then_all.call_or_else('pass', &fallback_fun)).to eq('pass')
+    expect(all_and_then_pass.defined_at?('pass')).to eq(true)
+    expect(pass_and_then_all.defined_at?('pass')).to eq(true)
 
-    expect(all_and_then_pass.call_or_else("longpass", &fallback_fun)).to eq("longpass")
-    expect(pass_and_then_all.call_or_else("longpass", &fallback_fun)).to eq("longpass")
-    expect(all_and_then_pass.defined_at?("longpass")).to eq(true)
-    expect(pass_and_then_all.defined_at?("longpass")).to eq(true)
+    expect(all_and_then_pass.call_or_else('longpass', &fallback_fun)).to eq('longpass')
+    expect(pass_and_then_all.call_or_else('longpass', &fallback_fun)).to eq('longpass')
+    expect(all_and_then_pass.defined_at?('longpass')).to eq(true)
+    expect(pass_and_then_all.defined_at?('longpass')).to eq(true)
 
-    expect(all_and_then_short.call_or_else("longpass", &fallback_fun)).to eq("fallback")
-    expect(short_and_then_all.call_or_else("longpass", &fallback_fun)).to eq("fallback")
-    expect(all_and_then_short.defined_at?("longpass")).to eq(false)
-    expect(short_and_then_all.defined_at?("longpass")).to eq(false)
+    expect(all_and_then_short.call_or_else('longpass', &fallback_fun)).to eq('fallback')
+    expect(short_and_then_all.call_or_else('longpass', &fallback_fun)).to eq('fallback')
+    expect(all_and_then_short.defined_at?('longpass')).to eq(false)
+    expect(short_and_then_all.defined_at?('longpass')).to eq(false)
 
-    expect(all_and_then_pass.call_or_else("longstr", &fallback_fun)).to eq("fallback")
-    expect(pass_and_then_all.call_or_else("longstr", &fallback_fun)).to eq("fallback")
-    expect(all_and_then_pass.defined_at?("longstr")).to eq(false)
-    expect(pass_and_then_all.defined_at?("longstr")).to eq(false)
+    expect(all_and_then_pass.call_or_else('longstr', &fallback_fun)).to eq('fallback')
+    expect(pass_and_then_all.call_or_else('longstr', &fallback_fun)).to eq('fallback')
+    expect(all_and_then_pass.defined_at?('longstr')).to eq(false)
+    expect(pass_and_then_all.defined_at?('longstr')).to eq(false)
 
-    expect(pass_and_then_short.call_or_else("pass", &fallback_fun)).to eq("pass")
-    expect(short_and_then_pass.call_or_else("pass", &fallback_fun)).to eq("pass")
-    expect(pass_and_then_short.defined_at?("pass")).to eq(true)
-    expect(short_and_then_pass.defined_at?("pass")).to eq(true)
+    expect(pass_and_then_short.call_or_else('pass', &fallback_fun)).to eq('pass')
+    expect(short_and_then_pass.call_or_else('pass', &fallback_fun)).to eq('pass')
+    expect(pass_and_then_short.defined_at?('pass')).to eq(true)
+    expect(short_and_then_pass.defined_at?('pass')).to eq(true)
 
-    expect(pass_and_then_short.call_or_else("longpass", &fallback_fun)).to eq("fallback")
-    expect(short_and_then_pass.call_or_else("longpass", &fallback_fun)).to eq("fallback")
-    expect(pass_and_then_short.defined_at?("longpass")).to eq(false)
-    expect(short_and_then_pass.defined_at?("longpass")).to eq(false)
+    expect(pass_and_then_short.call_or_else('longpass', &fallback_fun)).to eq('fallback')
+    expect(short_and_then_pass.call_or_else('longpass', &fallback_fun)).to eq('fallback')
+    expect(pass_and_then_short.defined_at?('longpass')).to eq(false)
+    expect(short_and_then_pass.defined_at?('longpass')).to eq(false)
 
-    expect(short_and_then_pass.call_or_else("longstr", &fallback_fun)).to eq("fallback")
-    expect(pass_and_then_short.call_or_else("longstr", &fallback_fun)).to eq("fallback")
-    expect(short_and_then_pass.defined_at?("longstr")).to eq(false)
-    expect(pass_and_then_short.defined_at?("longstr")).to eq(false)
+    expect(short_and_then_pass.call_or_else('longstr', &fallback_fun)).to eq('fallback')
+    expect(pass_and_then_short.call_or_else('longstr', &fallback_fun)).to eq('fallback')
+    expect(short_and_then_pass.defined_at?('longstr')).to eq(false)
+    expect(pass_and_then_short.defined_at?('longstr')).to eq(false)
   end
 end

--- a/spec/fear/partial_function_composition_spec.rb
+++ b/spec/fear/partial_function_composition_spec.rb
@@ -1,0 +1,60 @@
+require 'any'
+# This file contains tests from
+# https://github.com/scala/scala/blob/2.13.x/test/junit/scala/PartialFunctionCompositionTest.scala
+RSpec.describe Fear::PartialFunction do
+  include Fear::PartialFunction::Mixin
+
+  let(:fallback_fun) { ->(_) { 'fallback'} }
+  let(:pass_all) { PartialFunction(Any) { |x| x } }
+  let(:pass_short) { PartialFunction(->(x) { x.length < 5 }) { |x| x } }
+  let(:pass_pass) { PartialFunction(->(x) { x.include?('pass') }) { |x| x } }
+
+  let(:all_and_then_short) { pass_all & pass_short }
+  let(:short_and_then_all) { pass_short & pass_all }
+  let(:all_and_then_pass) { pass_all & pass_pass }
+  let(:pass_and_then_all) { pass_pass & pass_all }
+  let(:pass_and_then_short) { pass_pass & pass_short }
+  let(:short_and_then_pass) { pass_short & pass_pass }
+
+  it '#and_then' do
+    expect(all_and_then_short.call_or_else("pass", &fallback_fun)).to eq('pass')
+    expect(short_and_then_all.call_or_else("pass", &fallback_fun)).to eq("pass")
+    expect(all_and_then_short.defined_at?("pass")).to eq(true)
+    expect(short_and_then_all.defined_at?("pass")).to eq(true)
+
+    expect(all_and_then_pass.call_or_else("pass", &fallback_fun)).to eq("pass")
+    expect(pass_and_then_all.call_or_else("pass", &fallback_fun)).to eq("pass")
+    expect(all_and_then_pass.defined_at?("pass")).to eq(true)
+    expect(pass_and_then_all.defined_at?("pass")).to eq(true)
+
+    expect(all_and_then_pass.call_or_else("longpass", &fallback_fun)).to eq("longpass")
+    expect(pass_and_then_all.call_or_else("longpass", &fallback_fun)).to eq("longpass")
+    expect(all_and_then_pass.defined_at?("longpass")).to eq(true)
+    expect(pass_and_then_all.defined_at?("longpass")).to eq(true)
+
+    expect(all_and_then_short.call_or_else("longpass", &fallback_fun)).to eq("fallback")
+    expect(short_and_then_all.call_or_else("longpass", &fallback_fun)).to eq("fallback")
+    expect(all_and_then_short.defined_at?("longpass")).to eq(false)
+    expect(short_and_then_all.defined_at?("longpass")).to eq(false)
+
+    expect(all_and_then_pass.call_or_else("longstr", &fallback_fun)).to eq("fallback")
+    expect(pass_and_then_all.call_or_else("longstr", &fallback_fun)).to eq("fallback")
+    expect(all_and_then_pass.defined_at?("longstr")).to eq(false)
+    expect(pass_and_then_all.defined_at?("longstr")).to eq(false)
+
+    expect(pass_and_then_short.call_or_else("pass", &fallback_fun)).to eq("pass")
+    expect(short_and_then_pass.call_or_else("pass", &fallback_fun)).to eq("pass")
+    expect(pass_and_then_short.defined_at?("pass")).to eq(true)
+    expect(short_and_then_pass.defined_at?("pass")).to eq(true)
+
+    expect(pass_and_then_short.call_or_else("longpass", &fallback_fun)).to eq("fallback")
+    expect(short_and_then_pass.call_or_else("longpass", &fallback_fun)).to eq("fallback")
+    expect(pass_and_then_short.defined_at?("longpass")).to eq(false)
+    expect(short_and_then_pass.defined_at?("longpass")).to eq(false)
+
+    expect(short_and_then_pass.call_or_else("longstr", &fallback_fun)).to eq("fallback")
+    expect(pass_and_then_short.call_or_else("longstr", &fallback_fun)).to eq("fallback")
+    expect(short_and_then_pass.defined_at?("longstr")).to eq(false)
+    expect(pass_and_then_short.defined_at?("longstr")).to eq(false)
+  end
+end

--- a/spec/fear/partial_function_or_else_spec.rb
+++ b/spec/fear/partial_function_or_else_spec.rb
@@ -1,0 +1,276 @@
+RSpec.describe Fear::PartialFunction, '#or_else' do
+  include Fear::PartialFunction::Mixin
+
+  subject(:first_or_else_second) { first.or_else(second) }
+
+  let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
+  let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}"} }
+
+  describe '#defined_at?' do
+    context 'first defined, second not' do
+      subject { first_or_else_second.defined_at?(4) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'first not defined, second defined' do
+      subject { first_or_else_second.defined_at?(9) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'first not defined, second not defined' do
+      subject { first_or_else_second.defined_at?(5) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'first and second defined' do
+      subject { first_or_else_second.defined_at?(6) }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe '#call' do
+    context 'first defined, second not' do
+      subject { first_or_else_second.call(4) }
+
+      it { is_expected.to eq('first: 4') }
+    end
+
+    context 'first not defined, second defined' do
+      subject { first_or_else_second.call(9) }
+
+      it { is_expected.to eq('second: 9') }
+    end
+
+    context 'first not defined, second not defined' do
+      subject { -> { first_or_else_second.call(5) } }
+
+      it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 5') }
+    end
+
+    context 'first and second defined' do
+      subject { first_or_else_second.call(6) }
+
+      it { is_expected.to eq('first: 6') }
+    end
+  end
+
+  describe '#call_or_else' do
+    let(:fallback) { ->(x) { "fallback: #{x}" } }
+
+    context 'first defined, second not' do
+      subject { first_or_else_second.call_or_else(4, &fallback) }
+
+      it { is_expected.to eq('first: 4') }
+    end
+
+    context 'first not defined, second defined' do
+      subject { first_or_else_second.call_or_else(9, &fallback) }
+
+      it { is_expected.to eq('second: 9') }
+    end
+
+    context 'first not defined, second not defined' do
+      subject { first_or_else_second.call_or_else(5, &fallback) }
+
+      it { is_expected.to eq('fallback: 5') }
+    end
+
+    context 'first and second defined' do
+      subject { first_or_else_second.call_or_else(6, &fallback) }
+
+      it { is_expected.to eq('first: 6') }
+    end
+  end
+
+  describe '#or_else' do
+    let(:first_or_else_second_or_else_third) { first_or_else_second.or_else(third) }
+    let(:third) { PartialFunction(->(x) { x % 7 == 0}) { |x| "third: #{x}"} }
+
+    describe '#defined_at?' do
+      context 'first defined, second not' do
+        subject { first_or_else_second_or_else_third.defined_at?(4) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'first not defined, second defined' do
+        subject { first_or_else_second_or_else_third.defined_at?(9) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'first not defined, second not defined, third defined' do
+        subject { first_or_else_second_or_else_third.defined_at?(7) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'first not defined, second not defined, third not defined' do
+        subject { first_or_else_second_or_else_third.defined_at?(1) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'first, second and third defined' do
+        subject { first_or_else_second.defined_at?(42) }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    describe '#call' do
+      context 'first defined, second not' do
+        subject { first_or_else_second_or_else_third.call(4) }
+
+        it { is_expected.to eq('first: 4') }
+      end
+
+      context 'first not defined, second defined' do
+        subject { first_or_else_second_or_else_third.call(9) }
+
+        it { is_expected.to eq('second: 9') }
+      end
+
+      context 'first not defined, second not defined, third defined' do
+        subject { first_or_else_second_or_else_third.call(7) }
+
+        it { is_expected.to eq('third: 7') }
+      end
+
+      context 'first not defined, second not defined, third not defined' do
+        subject { -> { first_or_else_second_or_else_third.call(1) } }
+
+        it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 1') }
+      end
+
+      context 'first, second and third defined' do
+        subject { first_or_else_second.call(42) }
+
+        it { is_expected.to eq('first: 42') }
+      end
+    end
+
+    describe '#call_or_else' do
+      let(:fallback) { ->(x) { "fallback: #{x}" } }
+
+      context 'first defined, second not' do
+        subject { first_or_else_second_or_else_third.call_or_else(4, &fallback) }
+
+        it { is_expected.to eq('first: 4') }
+      end
+
+      context 'first not defined, second defined' do
+        subject { first_or_else_second_or_else_third.call_or_else(9, &fallback) }
+
+        it { is_expected.to eq('second: 9') }
+      end
+
+      context 'first not defined, second not defined, third defined' do
+        subject { first_or_else_second_or_else_third.call_or_else(7, &fallback) }
+
+        it { is_expected.to eq('third: 7') }
+      end
+
+      context 'first not defined, second not defined, third not defined' do
+        subject { first_or_else_second_or_else_third.call_or_else(1, &fallback) }
+
+        it { is_expected.to eq('fallback: 1') }
+      end
+
+      context 'first, second and third defined' do
+        subject { first_or_else_second_or_else_third.call_or_else(42, &fallback) }
+
+        it { is_expected.to eq('first: 42') }
+      end
+    end
+  end
+
+  describe '#and_then' do
+    let(:first_or_else_second_and_then_function) { first_or_else_second.and_then(&function) }
+    let(:function) { ->(x) { "f: #{x}" } }
+
+    describe '#defined_at?' do
+      context 'first defined, second not' do
+        subject { first_or_else_second_and_then_function.defined_at?(2) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'first not defined, second defined' do
+        subject { first_or_else_second_and_then_function.defined_at?(3) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'first not defined, second not defined' do
+        subject { first_or_else_second_and_then_function.defined_at?(5) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'first defined, second defined' do
+        subject { first_or_else_second_and_then_function.defined_at?(6) }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    describe '#call' do
+      context 'first defined, second not' do
+        subject { first_or_else_second_and_then_function.call(2) }
+
+        it { is_expected.to eq('f: first: 2') }
+      end
+
+      context 'first not defined, second defined' do
+        subject { first_or_else_second_and_then_function.call(3) }
+
+        it { is_expected.to eq('f: second: 3') }
+      end
+
+      context 'first not defined, second not defined' do
+        subject { -> { first_or_else_second_and_then_function.call(5) } }
+
+        it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 5') }
+      end
+
+      context 'first defined, second defined' do
+        subject { first_or_else_second_and_then_function.call(6) }
+
+        it { is_expected.to eq('f: first: 6') }
+      end
+    end
+
+    describe '#call_or_else' do
+      let(:fallback) { ->(x) { "fallback: #{x}" } }
+
+      context 'first defined, second not' do
+        subject { first_or_else_second_and_then_function.call_or_else(2, &fallback) }
+
+        it { is_expected.to eq('f: first: 2') }
+      end
+
+      context 'first not defined, second defined' do
+        subject { first_or_else_second_and_then_function.call_or_else(3, &fallback) }
+
+        it { is_expected.to eq('f: second: 3') }
+      end
+
+      context 'first not defined, second not defined' do
+        subject { first_or_else_second_and_then_function.call_or_else(5, &fallback) }
+
+        it { is_expected.to eq('fallback: 5') }
+      end
+
+      context 'first defined, second defined' do
+        subject { first_or_else_second_and_then_function.call_or_else(6, &fallback) }
+
+        it { is_expected.to eq('f: first: 6') }
+      end
+    end
+  end
+end

--- a/spec/fear/partial_function_or_else_spec.rb
+++ b/spec/fear/partial_function_or_else_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Fear::PartialFunction, '#or_else' do
 
   subject(:first_or_else_second) { first.or_else(second) }
 
-  let(:first) { PartialFunction(->(x) { x % 2 == 0 }) { |x| "first: #{x}" } }
-  let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}"} }
+  let(:first) { PartialFunction(->(x) { x.even? }) { |x| "first: #{x}" } }
+  let(:second) { PartialFunction(->(x) { x % 3 == 0 }) { |x| "second: #{x}" } }
 
   describe '#defined_at?' do
     context 'first defined, second not' do
@@ -88,7 +88,7 @@ RSpec.describe Fear::PartialFunction, '#or_else' do
 
   describe '#or_else' do
     let(:first_or_else_second_or_else_third) { first_or_else_second.or_else(third) }
-    let(:third) { PartialFunction(->(x) { x % 7 == 0}) { |x| "third: #{x}"} }
+    let(:third) { PartialFunction(->(x) { x % 7 == 0 }) { |x| "third: #{x}" } }
 
     describe '#defined_at?' do
       context 'first defined, second not' do

--- a/spec/fear/partial_function_spec.rb
+++ b/spec/fear/partial_function_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe Fear::PartialFunction do
+  include Fear::PartialFunction::Mixin
+
+  describe '#defined?' do
+    let(:partial_function) { PartialFunction(->(v) { v == 42 }) { } }
+
+    it 'defined at' do
+      expect(partial_function.defined_at?(42)).to eq(true)
+    end
+
+    it 'not defined at' do
+      expect(partial_function.defined_at?(24)).to eq(false)
+    end
+  end
+
+  describe '#call' do
+    let(:partial_function) { PartialFunction(->(v) { v != 0 }) { |x| 4 / x } }
+
+    context 'defined' do
+      subject { partial_function.call(2) }
+
+      it { is_expected.to eq(2) }
+    end
+
+    context 'not defined' do
+      subject { -> { partial_function.call(0) } }
+
+      it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 0') }
+    end
+  end
+
+  describe '#call_or_else' do
+    let(:default) { ->(x) { "division by #{x} impossible" } }
+    let(:partial_function) { PartialFunction(->(x) { x != 0 }) { |x| 4 / x } }
+
+    context 'defined' do
+      subject { partial_function.call_or_else(2, &default) }
+
+      it { is_expected.to eq(2) }
+    end
+
+    context 'not defined' do
+      subject { partial_function.call_or_else(0, &default) }
+
+      it { is_expected.to eq('division by 0 impossible') }
+    end
+  end
+
+  describe '#and_then' do
+    let(:partial_function) { PartialFunction(->(v) { v == 42 }) { } }
+    let(:and_then) { ->(x) { x } }
+
+    context 'block given, arguments not given' do
+      subject { -> { partial_function.and_then(&and_then) } }
+
+      it { is_expected.not_to raise_error }
+    end
+
+    context 'block given, argument given' do
+      subject { -> { partial_function.and_then(and_then, &and_then) } }
+
+      it { is_expected.to raise_error(ArgumentError) }
+    end
+
+    context 'block given, arguments given' do
+      subject { -> { partial_function.and_then(and_then, 42, &and_then) } }
+
+      it { is_expected.to raise_error(ArgumentError) }
+    end
+
+    context 'block not given, arguments not given' do
+      subject { -> { partial_function.and_then() } }
+
+      it { is_expected.to raise_error(ArgumentError) }
+    end
+
+    context 'block net given, arguments given' do
+      subject { -> { partial_function.and_then(and_then) } }
+
+      it { is_expected.not_to raise_error }
+    end
+  end
+end

--- a/spec/fear/partial_function_spec.rb
+++ b/spec/fear/partial_function_spec.rb
@@ -1,6 +1,47 @@
 RSpec.describe Fear::PartialFunction do
   include Fear::PartialFunction::Mixin
 
+  describe 'PartialFunction()' do
+    context 'condition as symbol' do
+      subject { PartialFunction(:even?) { |x| x } }
+
+      it 'converted to proc' do
+        is_expected.to be_defined_at(4)
+        is_expected.not_to be_defined_at(3)
+      end
+    end
+
+    context 'condition as Class' do
+      subject { PartialFunction(Integer) { |x| x } }
+
+      it do
+        is_expected.to be_defined_at(4)
+        is_expected.not_to be_defined_at('3')
+      end
+    end
+
+    context 'condition as Proc' do
+      subject { PartialFunction(->(x) { x.even? }) { |x| x } }
+
+      it do
+        is_expected.to be_defined_at(4)
+        is_expected.not_to be_defined_at(3)
+      end
+    end
+
+    context 'multiple condition' do
+      subject { PartialFunction(Integer, :even?, ->(x) { x % 3 == 0 }) { |x| x } }
+
+      it do
+        is_expected.to be_defined_at(12)
+        is_expected.not_to be_defined_at(12.0)
+        is_expected.not_to be_defined_at('3')
+        is_expected.not_to be_defined_at(3)
+        is_expected.not_to be_defined_at(4)
+      end
+    end
+  end
+
   describe '#defined?' do
     let(:partial_function) { PartialFunction(->(v) { v == 42 }) {} }
 

--- a/spec/fear/partial_function_spec.rb
+++ b/spec/fear/partial_function_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Fear::PartialFunction do
   include Fear::PartialFunction::Mixin
 
   describe '#defined?' do
-    let(:partial_function) { PartialFunction(->(v) { v == 42 }) { } }
+    let(:partial_function) { PartialFunction(->(v) { v == 42 }) {} }
 
     it 'defined at' do
       expect(partial_function.defined_at?(42)).to eq(true)
@@ -15,6 +15,22 @@ RSpec.describe Fear::PartialFunction do
 
   describe '#call' do
     let(:partial_function) { PartialFunction(->(v) { v != 0 }) { |x| 4 / x } }
+
+    context 'defined' do
+      subject { partial_function.call(2) }
+
+      it { is_expected.to eq(2) }
+    end
+
+    context 'not defined' do
+      subject { -> { partial_function.call(0) } }
+
+      it { is_expected.to raise_error(Fear::MatchError, 'partial function not defined at: 0') }
+    end
+  end
+
+  describe '#to_proc', '#call' do
+    let(:partial_function) { PartialFunction(->(v) { v != 0 }) { |x| 4 / x }.to_proc }
 
     context 'defined' do
       subject { partial_function.call(2) }
@@ -47,7 +63,7 @@ RSpec.describe Fear::PartialFunction do
   end
 
   describe '#and_then' do
-    let(:partial_function) { PartialFunction(->(v) { v == 42 }) { } }
+    let(:partial_function) { PartialFunction(->(v) { v == 42 }) {} }
     let(:and_then) { ->(x) { x } }
 
     context 'block given, arguments not given' do
@@ -69,7 +85,7 @@ RSpec.describe Fear::PartialFunction do
     end
 
     context 'block not given, arguments not given' do
-      subject { -> { partial_function.and_then() } }
+      subject { -> { partial_function.and_then } }
 
       it { is_expected.to raise_error(ArgumentError) }
     end


### PR DESCRIPTION
Implement `Fear::PartialFunction` as the first step toward pattern matching without using Qo gem. 

Idea borrowed from Scala (as usual), but optimisations for PF composition is more ruby-ish. Here are benchmarks:

Originally, scala uses marker objet to avoid calling  `#defined_at?`/`#call` method twice. I tried several approaches:

1. Marker object
```ruby
FALLBACK = ->(*) { FALLBACK }
def fallback_occurred(x)
  x.__id__ == FALLBACK.__id__
end

def call_or_else(arg)
  result = partial_function.call_or_else(arg, &FALLBACK)
  if fallback_occurred(result)
    yield arg
  else
    function.call(result)
  end
end
```

2. Marker object with `throw/catch` 
```ruby
TAG = Object.new.freeze

def call_or_else(arg)
  catch(TAG) do
    result = partial_function.call_or_else(arg) { throw(TAG, yield(arg)) }
    function.call(result)
  end
end
```
3. Returning from `Proc`
```ruby
def call_or_else(arg)
  result = partial_function.call_or_else(arg) do
    return yield(arg)
  end
  function.call(result)
end
```

First two approaches seems quite the same, the third one is the fastest.

## Benchmarks

### `Fear::PartialFunction::AndThen#call_or_else(&proc)`

```
> rake perf:and_then:call_or_else_proc
AndThen#call_or_else optimized return
                          2.035M (± 4.0%) i/s -     10.177M in   5.011107s
AndThen#call_or_else not optimized
                          1.155M (± 5.0%) i/s -      5.773M in   5.011145s

Comparison:
AndThen#call_or_else optimized return:  2034686.1 i/s
AndThen#call_or_else not optimized:  1155203.0 i/s - 1.76x  slower

Calculating -------------------------------------
AndThen#call_or_else optimized scalish
                          1.561M (± 6.7%) i/s -      7.827M in   5.041007s
AndThen#call_or_else not optimized
                          1.071M (±15.5%) i/s -      5.236M in   5.048209s

Comparison:
AndThen#call_or_else optimized scalish:  1560805.8 i/s
AndThen#call_or_else not optimized:  1071406.8 i/s - 1.46x  slower

Calculating -------------------------------------
AndThen#call_or_else optimized rubish
                          1.386M (±10.1%) i/s -      6.853M in   5.000400s
AndThen#call_or_else not optimized
                          1.004M (±10.9%) i/s -      5.010M in   5.055563s

Comparison:
AndThen#call_or_else optimized rubish:  1386063.0 i/s
AndThen#call_or_else not optimized:  1003617.5 i/s - 1.38x  slower
```

Marker object is a bit faster than `throw/catch`, but returning from proc seems the fastest.

### `Fear::PartialFunction::Combined#call_or_else(partial_function)`
*Need to investigate* 

```
> rake perf:and_then:call_or_else_partial_function

Calculating -------------------------------------
Combined#call_or_else optimized
                        944.289k (± 4.6%) i/s -      4.815M in   5.110704s
Combined#call_or_else not optimized
                          1.073M (± 4.5%) i/s -      5.400M in   5.043993s

Comparison:
Combined#call_or_else not optimized:  1072905.6 i/s
Combined#call_or_else optimized:   944289.1 i/s - 1.14x  slower
```

### `Fear::PartialFunction::Combined#defined_at?(partial_function)`

```
> rake perf:and_then:defined_at_partial_function

Calculating -------------------------------------
Combined#defined_at? optimized
                          2.788M (± 3.9%) i/s -     14.036M in   5.043433s
Combined#defined_at? not optimized
                          1.421M (± 2.4%) i/s -      7.193M in   5.063232s

Comparison:
Combined#defined_at? optimized:  2787652.7 i/s
Combined#defined_at? not optimized:  1421464.5 i/s - 1.96x  slower
```

### `Fear::PartialFunction::OrElse#call_or_else`

```
> rake perf:or_else:call_or_else
Calculating -------------------------------------
OrElse#call_or_else optimized
                          2.281M (± 2.6%) i/s -     11.399M in   5.001531s
OrElse#call_or_else not optimized
                        852.482k (± 3.9%) i/s -      4.309M in   5.063553s

Comparison:
OrElse#call_or_else optimized:  2280685.9 i/s
OrElse#call_or_else not optimized:   852481.7 i/s - 2.68x  slower
```

### `Fear::PartialFunction::OrElse#or_else`

```
>rake perf:or_else:or_else
Calculating -------------------------------------
OrElse#or_else#call_or_else optimized
                          1.432M (± 2.1%) i/s -      7.211M in   5.036721s
OrElse#or_else#call_or_else not optimized
                        844.632k (± 4.5%) i/s -      4.260M in   5.054738s

Comparison:
OrElse#or_else#call_or_else optimized:  1432394.5 i/s
OrElse#or_else#call_or_else not optimized:   844632.1 i/s - 1.70x  slower
```

### `Fear::PartialFunction::OrElse#and_then`

```
> rake perf:or_else:and_then
Calculating -------------------------------------
OrElse#or_else#and_then optimized
                          1.212M (±12.1%) i/s -      5.995M in   5.029510s
OrElse#or_else#and_then not optimized
                        742.300k (±10.8%) i/s -      3.690M in   5.038267s

Comparison:
OrElse#or_else#and_then optimized:  1211901.9 i/s
OrElse#or_else#and_then not optimized:   742299.8 i/s - 1.63x  slower
```