### PR TITLE
Add pattern compilation caching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
   remote: .
   specs:
     fear (0.11.0)
+      lru_redux
       treetop
 
 GEM
@@ -20,6 +21,7 @@ GEM
     diff-lcs (1.3)
     dry-matcher (0.7.0)
     jaro_winkler (1.5.2)
+    lru_redux (1.1.0)
     parallel (1.14.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,27 @@ require 'benchmark/ips'
 require_relative 'lib/fear'
 
 namespace :perf do
+  task :pattern_matching_with_without_cache do
+    some = Fear.some([:err, 'not found'])
+
+    class WOCache < Fear::Extractor::Pattern
+      def initialize(pattern)
+        @matcher = compile_pattern_without_cache(pattern)
+      end
+    end
+
+    Benchmark.ips do |x|
+      x.report('With cache') do |_n|
+        Fear::Extractor::Pattern.new('Fear::Some([:err, code])') === some
+      end
+
+      x.report('Without cache') do |_n|
+        WOCache.new('Fear::Some([:err, code])') === some
+      end
+
+      x.compare!
+    end
+  end
   namespace :guard do
     task :and1 do
       condition = Integer

--- a/fear.gemspec
+++ b/fear.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
     Successfully installed fear-#{Fear::VERSION}
   MSG
 
+  spec.add_runtime_dependency 'lru_redux'
   spec.add_runtime_dependency 'treetop'
 
   spec.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
There is no need to compile pattern each time it's executed. By utilising caching, we can get 380x boost in speed:

```
Warming up --------------------------------------
          With cache     3.182k i/100ms
       Without cache   170.000  i/100ms
Calculating -------------------------------------
          With cache    115.861M (±16.5%) i/s -    529.660M in   4.932930s
       Without cache    305.813k (±14.5%) i/s -      1.472M in   4.994141s

Comparison:
          With cache: 115860895.4 i/s
       Without cache:   305812.8 i/s - 378.86x  slower
```