### PR TITLE
Don't treat symbols as procs while pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.x
 
+* Don't treat symbols as procs while pattern matching. See [#46](https://github.com/bolshakov/fear/pull/46) for motivation ([@bolshakov][])
 * Revert commit removing `Fear::Future`. Now you can use `Fear.future` again ([@bolshakov][])
 * Signatures of `Try#recover` and `Try#recover_with` changed. No it pattern match against container
   see https://github.com/bolshakov/fear/issues/41 for details . ([@bolshakov][])

--- a/README.md
+++ b/README.md
@@ -904,14 +904,9 @@ You can use whatever you want as a pattern guard, if it respond to `#===` method
 
 ```ruby
 m.case(20..40) { |m| "#{m} is within range" }
-m.case(->(x) { x > 10}) { |m| "#{m} is greater than 10" }
-```
-
-In sake of convenience, passing a Symbol, converts it to proc using `#to_proc` method
-
-```ruby 
-m.case(:even?) { |x| "#{x} is even" }
-m.case(:odd?) { |x| "#{x} is odd" }
+m.case(->(x) { x > 10}) { |m| "#{m} is greater than 10" } 
+m.case(:even?.to_proc) { |x| "#{x} is even" }
+m.case(:odd?.to_proc) { |x| "#{x} is odd" }
 ```
 
 It's also possible to create matcher and use it several times:
@@ -1129,8 +1124,8 @@ pattern match on enclosed value
 
 ```ruby
 Fear.some(41).match do |m|
-  m.some(:even?) { |x| x / 2 }
-  m.some(:odd?, ->(v) { v > 0 }) { |x| x * 2 }
+  m.some(:even?.to_proc) { |x| x / 2 }
+  m.some(:odd?.to_proc, ->(v) { v > 0 }) { |x| x * 2 }
   m.none { 'none' }
 end #=> 82
 ``` 
@@ -1139,7 +1134,7 @@ it raises `Fear::MatchError` error if nothing matched. To avoid exception, you c
 
 ```ruby
 Fear.some(42).match do |m|
-  m.some(:odd?) { |x| x * 2 }
+  m.some(:odd?.to_proc) { |x| x * 2 }
   m.else { 'nothing' }
 end #=> nothing
 ```
@@ -1179,8 +1174,7 @@ It uses `#===` method under the hood, so you can pass:
 
 * Class to check kind of an object.
 * Lambda to evaluate it against an object.
-* Any literal, like `4`, `"Foobar"`, etc.
-* Symbol -- it is converted to lambda using `#to_proc` method.
+* Any literal, like `4`, `"Foobar"`, `:not_found` etc.
 * Qo matcher -- `m.case(Qo[name: 'John']) { .... }`
  
 Partial functions may be combined with each other:

--- a/lib/fear/for.rb
+++ b/lib/fear/for.rb
@@ -58,7 +58,7 @@ module Fear
     #   For(Fear.success(2), Fear.failure(...)) { |a, b| a * b }  #=> Fear.failure(...)
     #
     module Mixin
-      # @param monads [Hash{Symbol => {#map, #flat_map}}]
+      # @param monads [{#map, #flat_map}]
       # @return [{#map, #flat_map}]
       #
       def For(*monads, &block)

--- a/lib/fear/for_api.rb
+++ b/lib/fear/for_api.rb
@@ -56,7 +56,7 @@ module Fear
     #       "#{user.name} was born on #{birthday}"
     #     end #=> Fear.some('Paul was born on 1987-06-17')
     #
-    # @param monads [Hash{Symbol => {#map, #flat_map}}]
+    # @param monads [{#map, #flat_map}]
     # @return [{#map, #flat_map}]
     #
     def for(*monads, &block)

--- a/lib/fear/partial_function.rb
+++ b/lib/fear/partial_function.rb
@@ -148,7 +148,7 @@ module Fear
     class << self
       # Creates partial function guarded by several condition.
       # All guards should match.
-      # @param guards [<#===, symbol>]
+      # @param guards [<#===>]
       # @param function [Proc]
       # @return [Fear::PartialFunction]
       def and(*guards, &function)
@@ -157,7 +157,7 @@ module Fear
 
       # Creates partial function guarded by several condition.
       # Any condition should match.
-      # @param guards [<#===, symbol>]
+      # @param guards [<#===>]
       # @param function [Proc]
       # @return [Fear::PartialFunction]
       def or(*guards, &function)

--- a/lib/fear/partial_function/guard.rb
+++ b/lib/fear/partial_function/guard.rb
@@ -11,28 +11,21 @@ module Fear
       class << self
         # Optimized version for combination of two guardians
         # Two guarding is a very common situation. For example checking for Some, and checking
-        # a value withing contianer.
+        # a value withing container.
         #
         def and2(c1, c2)
-          Guard::And.new(
-            (c1.is_a?(Symbol) ? c1.to_proc : c1),
-            (c2.is_a?(Symbol) ? c2.to_proc : c2),
-          )
+          Guard::And.new(c1, c2)
         end
 
         def and3(c1, c2, c3)
-          Guard::And3.new(
-            (c1.is_a?(Symbol) ? c1.to_proc : c1),
-            (c2.is_a?(Symbol) ? c2.to_proc : c2),
-            (c3.is_a?(Symbol) ? c3.to_proc : c3),
-          )
+          Guard::And3.new(c1, c2, c3)
         end
 
         def and1(c)
-          c.is_a?(Symbol) ? c.to_proc : c
+          c
         end
 
-        # @param conditions [<#===, Symbol>]
+        # @param conditions [<#===>]
         # @return [Fear::PartialFunction::Guard]
         def and(conditions)
           case conditions.size
@@ -46,7 +39,7 @@ module Fear
           end
         end
 
-        # @param conditions [<#===, Symbol>]
+        # @param conditions [<#===>]
         # @return [Fear::PartialFunction::Guard]
         def or(conditions)
           return Any if conditions.empty?
@@ -56,14 +49,9 @@ module Fear
         end
       end
 
-      # @param condition [<#===, Symbol>]
+      # @param condition [#===]
       def initialize(condition)
-        @condition =
-          if condition.is_a?(Symbol)
-            condition.to_proc
-          else
-            condition
-          end
+        @condition = condition
       end
       attr_reader :condition
       private :condition

--- a/lib/fear/pattern_matching_api.rb
+++ b/lib/fear/pattern_matching_api.rb
@@ -34,16 +34,13 @@ module Fear
     #
     #     m.case(20..40) { |m| "#{m} is within range" }
     #     m.case(->(x) { x > 10}) { |m| "#{m} is greater than 10" }
-    #
-    # If you pass a Symbol, it will be converted to proc using +#to_proc+ method
-    #
-    #     m.case(:even?) { |x| "#{x} is even" }
-    #     m.case(:odd?) { |x| "#{x} is odd" }
+    #     m.case(:even?.to_proc) { |x| "#{x} is even" }
+    #     m.case(:odd?.to_proc) { |x| "#{x} is odd" }
     #
     # It's also possible to pass several guardians. All should match to pass
     #
-    #     m.case(Integer, :even?) { |x| ... }
-    #     m.case(Integer, :odd?) { |x| ... }
+    #     m.case(Integer, :even?.to_proc) { |x| ... }
+    #     m.case(Integer, :odd?.to_proc) { |x| ... }
     #
     # If you want to perform pattern destruction, use +#xcase+ method
     #
@@ -76,8 +73,8 @@ module Fear
     #
     # @example
     #   Fear.match(42) do |m|
-    #     m.case(Integer, :even?) { |n| "#{n} is even number" }
-    #     m.case(Integer, :odd?) { |n| "#{n} is odd number" }
+    #     m.case(Integer, :even?.to_proc) { |n| "#{n} is even number" }
+    #     m.case(Integer, :odd?.to_proc) { |n| "#{n} is odd number" }
     #     m.case(Strings) { |n| "#{n} is a string" }
     #     m.else { 'unknown' }
     #   end #=> "42 is even number"
@@ -97,7 +94,7 @@ module Fear
     #   pf.defined_at?('Foo') #=> false
     #
     # @example multiple guards combined using logical "and"
-    #   pf = Fear.case(Integer, :even?) { |x| x / 2 }
+    #   pf = Fear.case(Integer, :even?.to_proc) { |x| x / 2 }
     #   pf.defined_at?(4) #=> true
     #   pf.defined_at?(3) #=> false
     #
@@ -106,7 +103,7 @@ module Fear
     # @example
     #   Fear.case(Qo[age: 20..30]) { |_| 'old enough' }
     #
-    # @param guards [<#===, symbol>]
+    # @param guards [<#===>]
     # @param function [Proc]
     # @return [Fear::PartialFunction]
     def case(*guards, &function)

--- a/spec/fear/either_pattern_match_spec.rb
+++ b/spec/fear/either_pattern_match_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Fear::EitherPatternMatch do
   context 'Right' do
     let(:matcher) do
       described_class.new do |m|
-        m.right(:even?) { |x| "#{x} is even" }
-        m.right(:odd?) { |x| "#{x} is odd" }
+        m.right(:even?.to_proc) { |x| "#{x} is even" }
+        m.right(:odd?.to_proc) { |x| "#{x} is odd" }
       end
     end
 
@@ -19,8 +19,8 @@ RSpec.describe Fear::EitherPatternMatch do
   context 'Left' do
     let(:matcher) do
       described_class.new do |m|
-        m.left(:even?) { |x| "#{x} is even" }
-        m.left(:odd?) { |x| "#{x} is odd" }
+        m.left(:even?.to_proc) { |x| "#{x} is even" }
+        m.left(:odd?.to_proc) { |x| "#{x} is odd" }
       end
     end
 

--- a/spec/fear/guard_spec.rb
+++ b/spec/fear/guard_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Fear::PartialFunction::Guard do
 
   context 'Symbol' do
     context 'match' do
-      subject { Fear::PartialFunction::Guard.new(:even?) === 4 }
+      subject { Fear::PartialFunction::Guard.new(:even?) === :even? }
 
       it { is_expected.to eq(true) }
     end
 
     context 'not match' do
-      subject { Fear::PartialFunction::Guard.new(:even?) === 3 }
+      subject { Fear::PartialFunction::Guard.new(:even?) === 4 }
 
       it { is_expected.to eq(false) }
     end
@@ -44,14 +44,14 @@ RSpec.describe Fear::PartialFunction::Guard do
   describe '.and' do
     context 'match' do
       subject { guard === 4 }
-      let(:guard) { Fear::PartialFunction::Guard.and([Integer, :even?, ->(x) { x.even? }]) }
+      let(:guard) { Fear::PartialFunction::Guard.and([Integer, :even?.to_proc, ->(x) { x.even? }]) }
 
       it { is_expected.to eq(true) }
     end
 
     context 'not match' do
       subject { guard === 3 }
-      let(:guard) { Fear::PartialFunction::Guard.and([Integer, :even?, ->(x) { x.even? }]) }
+      let(:guard) { Fear::PartialFunction::Guard.and([Integer, :even?.to_proc, ->(x) { x.even? }]) }
 
       it { is_expected.to eq(false) }
     end

--- a/spec/fear/option_pattern_match_spec.rb
+++ b/spec/fear/option_pattern_match_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Fear::OptionPatternMatch do
   context 'Some' do
     let(:matcher) do
       described_class.new do |m|
-        m.some(:even?) { |x| "#{x} is even" }
-        m.some(:odd?) { |x| "#{x} is odd" }
+        m.some(:even?.to_proc) { |x| "#{x} is even" }
+        m.some(:odd?.to_proc) { |x| "#{x} is odd" }
       end
     end
 

--- a/spec/fear/partial_function_spec.rb
+++ b/spec/fear/partial_function_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Fear::PartialFunction do
     context 'condition as symbol' do
       subject { Fear.case(:even?) { |x| x } }
 
-      it 'converted to proc' do
-        is_expected.to be_defined_at(4)
+      it 'matches against the same symbol' do
+        is_expected.to be_defined_at(:even?)
         is_expected.not_to be_defined_at(3)
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe Fear::PartialFunction do
     end
 
     context 'multiple condition' do
-      subject { Fear.case(Integer, :even?, ->(x) { x % 3 == 0 }) { |x| x } }
+      subject { Fear.case(Integer, :even?.to_proc, ->(x) { x % 3 == 0 }) { |x| x } }
 
       it do
         is_expected.to be_defined_at(12)

--- a/spec/fear/try_pattern_match_spec.rb
+++ b/spec/fear/try_pattern_match_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Fear::TryPatternMatch do
   context 'Success' do
     let(:matcher) do
       described_class.new do |m|
-        m.success(:even?) { |x| "#{x} is even" }
-        m.success(:odd?) { |x| "#{x} is odd" }
+        m.success(:even?.to_proc) { |x| "#{x} is even" }
+        m.success(:odd?.to_proc) { |x| "#{x} is odd" }
       end
     end
 


### PR DESCRIPTION
* Symbols often used as immutable identifiers, statuses etc
* Such behaviour may be confusing and unexpected
* Explicit is better then implicit

So, instead of writing this

```ruby
Fear.matcher do |m|
  m.case(:even?) { |v| ... }
end
```

You should either pass a lambda, or convert a Symbol to proc explicitly

```ruby
Fear.matcher do |m|
  m.case(:even?.to_proc) { |v| ... }
  m.case(->(v) { v.even? }) { |v| ... }
end
```