### PR TITLE
Add `Fear::Await.ready` and `Fear::Await.result`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.x
+## 1.1.0 
+
+* Add `Fear::Await.ready` and `Fear::Await.result`.
+
+## 1.0.0
 
 * Rename `Fear::Done` to `Fear::Unit` ([@bolshakov][])
 * Don't treat symbols as procs while pattern matching. See [#46](https://github.com/bolshakov/fear/pull/46) for motivation ([@bolshakov][])

--- a/README.md
+++ b/README.md
@@ -784,6 +784,20 @@ end.and_then do |m|
 end
 ```
 
+#### Testing future values
+
+Sometimes it may be helpful to await for future completion. You can await either future,
+or result. Don't forget to pass timeout in seconds:
+
+
+```ruby 
+future = Fear.future { 42 }
+
+Fear::Await.result(future, 3) #=> 42
+
+Fear::Await.ready(future, 3) #=> Fear::Future.successful(42)
+```
+
 ### For composition ([API Documentation](http://www.rubydoc.info/github/bolshakov/fear/master/Fear/ForApi))
 
 Provides syntactic sugar for composition of multiple monadic operations. 

--- a/lib/fear.rb
+++ b/lib/fear.rb
@@ -55,7 +55,10 @@ module Fear
   autoload :Right, 'fear/right'
   autoload :RightPatternMatch, 'fear/right_pattern_match'
 
+  autoload :Await, 'fear/await'
+  autoload :Awaitable, 'fear/awaitable'
   autoload :Future, 'fear/future'
+  autoload :Promise, 'fear/promise'
 
   module Mixin
     include Either::Mixin

--- a/lib/fear/await.rb
+++ b/lib/fear/await.rb
@@ -1,0 +1,31 @@
+module Fear
+  # You're strongly discouraged to use this module since it may lead to deadlocks,
+  # and reduced performance. Although, blocking may be useful in some cases (e.g. in tests)
+  #
+  # @see https://stackoverflow.com/questions/38155159/why-doesnt-scalas-future-have-a-get-getmaxduration-method-forcing-us-to
+  module Await
+    # Blocks until +Fear::Awaitable+ reached completed state and returns itself
+    # or raises +TimeoutError+
+    #
+    # @param awaitable [Fear::Awaitable]
+    # @param at_most [Fixnum] timeout in seconds
+    # @return [Fear::Awaitable]
+    # @raise [Timeout::Error]
+    #
+    module_function def ready(awaitable, at_most)
+      awaitable.__ready__(at_most)
+    end
+
+    # Blocks until +Fear::Awaitable+ reached completed state and returns its value
+    # or raises +TimeoutError+
+    #
+    # @param awaitable [Fear::Awaitable]
+    # @param at_most [Fixnum] timeout in seconds
+    # @return [any]
+    # @raise [Timeout::Error]
+    #
+    module_function def result(awaitable, at_most)
+      awaitable.__result__(at_most)
+    end
+  end
+end

--- a/lib/fear/awaitable.rb
+++ b/lib/fear/awaitable.rb
@@ -1,0 +1,26 @@
+module Fear
+  # An object which may eventually be completed and awaited using blocking methods.
+  #
+  # @abstract
+  # @api private
+  # @see Fear::Await
+  module Awaitable
+    # Await +completed+ state of this +Awaitable+
+    #
+    # @param at_most [Fixnum] maximum timeout in seconds
+    # @return [Fear::Awaitable]
+    # @raise [Timeout::Error]
+    def __ready__(_at_most)
+      raise NotImplementedError
+    end
+
+    # Await and return the result of this +Awaitable+
+    #
+    # @param at_most [Fixnum] maximum timeout in seconds
+    # @return [any]
+    # @raise [Timeout::Error]
+    def __result__(_at_most)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/fear/promise.rb
+++ b/lib/fear/promise.rb
@@ -1,3 +1,9 @@
+begin
+  require 'concurrent'
+rescue LoadError
+  puts "You must add 'concurrent-ruby' to your Gemfile in order to use Fear::Future"
+end
+
 module Fear
   # @api private
   class Promise < Concurrent::IVar


### PR DESCRIPTION
Sometimes it may be helpful to await for future completion. You can await either future,
or result. Don't forget to pass timeout in seconds:

```ruby
future = Fear.future { 42 }

Fear::Await.result(future, 3) #=> 42

Fear::Await.ready(future, 3) #=> Fear::Future.successful(42)
```