### PR TITLE
Implement immutable Fear::Struct

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,6 @@ Metrics/BlockLength:
 
 Metrics/LineLength:
   Max: 120
+
+Lint/UselessComparison:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `Fear::Await.ready` and `Fear::Await.result`.
 * Add callback versions with pattern matching `Fear::Future#on_success_match`, `#on_failure_match` and `#on_complete_match`.
+* Implement immutable `Fear::Struct` 
 
 ## 1.0.0
 

--- a/lib/fear.rb
+++ b/lib/fear.rb
@@ -60,6 +60,8 @@ module Fear
   autoload :Future, 'fear/future'
   autoload :Promise, 'fear/promise'
 
+  autoload :Struct, 'fear/struct'
+
   module Mixin
     include Either::Mixin
     include For::Mixin

--- a/lib/fear/extractor.rb
+++ b/lib/fear/extractor.rb
@@ -88,7 +88,7 @@ module Fear
         Fear.none
       end
     end)
-    register_extractor(Struct, Fear.case(Struct, &:to_a).lift)
+    register_extractor(::Struct, Fear.case(::Struct, &:to_a).lift)
     # No argument boolean extractor example
     register_extractor('IsEven', proc do |int|
       if int.is_a?(Integer) && int.even?

--- a/lib/fear/struct.rb
+++ b/lib/fear/struct.rb
@@ -1,0 +1,233 @@
+module Fear
+  # Structs are like regular classes and good for modeling immutable data.
+  #
+  # A minimal struct requires just a list of attributes:
+  #
+  #     User = Fear::Struct.with_attributes(:id, :email, :admin)
+  #     john = User.new(id: 2, email: 'john@example.com', admin: false)
+  #
+  #     john.email #=> 'john@example.com'
+  #
+  # Instead of `.with_attributes` factory method you can use classic inheritance:
+  #
+  #     class User < Fear::Struct
+  #       attribute :id
+  #       attribute :email
+  #       attribute :admin
+  #     end
+  #
+  # Since structs are immutable, you are not allowed to reassign their attributes
+  #
+  #     john.email = ''john.doe@example.com'' #=> raises NoMethodError
+  #
+  # Two structs of the same type with the same attributes are equal
+  #
+  #     john1 = User.new(id: 2, email: 'john@example.com', admin: false)
+  #     john2 = User.new(id: 2, admin: false, email: 'john@example.com')
+  #     john1 == john2 #=> true
+  #
+  # You can create a shallow copy of a +Struct+ by using copy method optionally changing its attributes.
+  #
+  #     john = User.new(id: 2, email: 'john@example.com', admin: false)
+  #     admin_john = john.copy(admin: true)
+  #
+  #     john.admin #=> false
+  #     admin_john.admin #=> true
+  #
+  # It's possible to match against struct attributes. The following example extracts email from
+  # user only if user is admin
+  #
+  #     john = User.new(id: 2, email: 'john@example.com', admin: false)
+  #     john.match |m|
+  #       m.xcase('Fear::Struct(_, email, true)') do |email|
+  #         email
+  #       end
+  #     end
+  #
+  # Note, parameters got extracted in order they was defined.
+  #
+  class Struct
+    include PatternMatch.mixin
+
+    @attributes = [].freeze
+
+    class << self
+      # @param base [Fear::Struct]
+      # @api private
+      def inherited(base)
+        base.instance_variable_set(:@attributes, attributes)
+        Fear.register_extractor(base, Fear.case(base, &:to_a).lift)
+      end
+
+      # Defines attribute
+      #
+      # @param name [Symbol]
+      # @return [Symbol] attribute name
+      #
+      # @example
+      #   class User < Fear::Struct
+      #     attribute :id
+      #     attribute :email
+      #   end
+      #
+      def attribute(name)
+        name.to_sym.tap do |symbolized_name|
+          @attributes << symbolized_name
+          attr_reader symbolized_name
+        end
+      end
+
+      # Members of this struct
+      #
+      # @return [<Symbol>]
+      def attributes
+        @attributes.dup
+      end
+
+      # Creates new struct with given attributes
+      # @param members [<Symbol>]
+      # @return [Fear::Struct]
+      #
+      # @example
+      #   User = Fear::Struct.with_attributes(:id, :email, :admin) do
+      #     def admin?
+      #       @admin
+      #     end
+      #   end
+      #
+      def with_attributes(*members, &block)
+        members = members
+        block = block
+
+        Class.new(self) do
+          members.each { |member| attribute(member) }
+          class_eval(&block) if block
+        end
+      end
+    end
+
+    # @param attributes [{Symbol => any}]
+    def initialize(**attributes)
+      _check_missing_attributes!(attributes)
+      _check_unknown_attributes!(attributes)
+
+      @values = members.each_with_object([]) do |name, values|
+        attributes.fetch(name).tap do |value|
+          _set_attribute(name, value)
+          values << value
+        end
+      end
+    end
+
+    # Creates a shallow copy of this struct optionally changing the attributes arguments.
+    # @param attributes [{Symbol => any}]
+    #
+    # @example
+    #   User = Fear::Struct.new(:id, :email, :admin)
+    #   john = User.new(id: 2, email: 'john@example.com', admin: false)
+    #   john.admin #=> false
+    #   admin_john = john.copy(admin: true)
+    #   admin_john.admin #=> true
+    #
+    def copy(**attributes)
+      self.class.new(to_h.merge(attributes))
+    end
+
+    # Returns the struct attributes as an array of symbols
+    # @return [<Symbol>]
+    #
+    # @example
+    #   User = Fear::Struct.new(:id, :email, :admin)
+    #   john = User.new(email: 'john@example.com', admin: false, id: 2)
+    #   john.attributes #=> [:id, :email, :admin]
+    #
+    def members
+      self.class.attributes
+    end
+
+    # Returns the values for this struct as an Array.
+    # @return [Array]
+    #
+    # @example
+    #   User = Fear::Struct.new(:id, :email, :admin)
+    #   john = User.new(email: 'john@example.com', admin: false, id: 2)
+    #   john.to_a #=> [2, 'john@example.com', false]
+    #
+    def to_a
+      @values.dup
+    end
+
+    # @overload to_h()
+    #   Returns a Hash containing the names and values for the struct's attributes
+    #   @return [{Symbol => any}]
+    #
+    # @overload to_h(&block)
+    #   Applies block to pairs of name name and value and use them to construct hash
+    #   @yieldparam pair [<Symbol, any>] yields pair of name name and value
+    #   @return [{Symbol => any}]
+    #
+    # @example
+    #   User = Fear::Struct.new(:id, :email, :admin)
+    #   john = User.new(email: 'john@example.com', admin: false, id: 2)
+    #   john.to_h #=> {id: 2, email: 'john@example.com', admin: false}
+    #   john.to_h do |key, value|
+    #     [key.to_s, value]
+    #   end #=> {'id' => 2, 'email' => 'john@example.com', 'admin' => false}
+    #
+    def to_h(&block)
+      pairs = members.zip(@values)
+      if block_given?
+        Hash[pairs.map(&block)]
+      else
+        Hash[pairs]
+      end
+    end
+
+    # @param other [any]
+    # @return [Boolean]
+    def ==(other)
+      other.is_a?(other.class) && to_h == other.to_h
+    end
+
+    INSPECT_TEMPLATE = '<#Fear::Struct %<class_name>s %<attributes>s>'.freeze
+
+    # @return [String]
+    #
+    # @example
+    #   User = Fear::Struct.with_attributes(:id, :email)
+    #   user = User.new(id: 2, email: 'john@exmaple.com')
+    #   user.inspect #=> "<#Fear::Struct User id=2, email=>'john@exmaple.com'>"
+    #
+    def inspect
+      attributes = to_h.map { |key, value| "#{key}=#{value.inspect}" }.join(', ')
+
+      format(INSPECT_TEMPLATE, class_name: self.class.name, attributes: attributes)
+    end
+    alias to_s inspect
+
+    MISSING_KEYWORDS_ERROR = 'missing keywords: %<keywords>s'.freeze
+
+    private def _check_missing_attributes!(provided_attributes)
+      missing_attributes = members - provided_attributes.keys
+
+      unless missing_attributes.empty?
+        raise ArgumentError, format(MISSING_KEYWORDS_ERROR, keywords: missing_attributes.join(', '))
+      end
+    end
+
+    UNKNOWN_KEYWORDS_ERROR = 'unknown keywords: %<keywords>s'.freeze
+
+    private def _check_unknown_attributes!(provided_attributes)
+      unknown_attributes = provided_attributes.keys - members
+
+      unless unknown_attributes.empty?
+        raise ArgumentError, format(UNKNOWN_KEYWORDS_ERROR, keywords: unknown_attributes.join(', '))
+      end
+    end
+
+    # @return [void]
+    private def _set_attribute(name, value)
+      instance_variable_set(:"@#{name}", value)
+    end
+  end
+end

--- a/spec/fear/extractor/extractor_matcher_spec.rb
+++ b/spec/fear/extractor/extractor_matcher_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Fear::Extractor::ExtractorMatcher do
     end
 
     context 'Struct' do
-      StructDate = Struct.new(:year, :month, :day)
+      StructDate = ::Struct.new(:year, :month, :day)
 
       let(:pattern) { 'StructDate(2017, month, _)' }
 

--- a/spec/fear/extractor_spec.rb
+++ b/spec/fear/extractor_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Fear::Extractor do
   describe '.register_extractor' do
-    Foo = Struct.new(:v1, :v2)
+    Foo = ::Struct.new(:v1, :v2)
     let(:matcher) do
       Fear.matcher do |m|
         m.case(Fear['Foo(43, second : Integer)']) { |second| "43 and #{second}" }

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -1,0 +1,224 @@
+RSpec.describe Fear::Struct do
+  describe '.with_attributes' do
+    context 'same arguments' do
+      subject { struct_class.new(a: 42, b: 43) }
+
+      let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+      it { is_expected.to have_attributes(a: 42, b: 43) }
+    end
+
+    context 'string arguments' do
+      subject { -> { struct_class.new('a' => 42, 'b' => 43) } }
+
+      let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+      it { is_expected.to raise_error(ArgumentError, 'wrong number of arguments (given 1, expected 0)') }
+    end
+
+    context 'extra argument' do
+      subject { -> { struct_class.new(a: 42, b: 41, c: 43, d: 44) } }
+
+      let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+      it { is_expected.to raise_error(ArgumentError, 'unknown keywords: c, d') }
+    end
+
+    context 'missing argument' do
+      subject { -> { struct_class.new } }
+
+      let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+      it { is_expected.to raise_error(ArgumentError, 'missing keywords: a, b') }
+    end
+
+    context 'inheritance' do
+      let(:parent_struct) { described_class.with_attributes(:a, :b) }
+
+      it 'does not change parent attributes' do
+        expect do
+          parent_struct.with_attributes(:c)
+        end.not_to change { parent_struct.attributes }.from(%i[a b])
+      end
+
+      it 'extends parent attributes' do
+        child_struct = parent_struct.with_attributes(:c)
+        expect(child_struct.attributes).to eq(%i[a b c])
+      end
+    end
+
+    context 'with block' do
+      subject { struct_class.new(a: 42, b: 43).a_plus_b }
+
+      let(:struct_class) do
+        described_class.with_attributes(:a, :b) do
+          def a_plus_b
+            a + b
+          end
+        end
+      end
+
+      it 'evaluates block in context of struct' do
+        is_expected.to eq(85)
+      end
+    end
+  end
+
+  describe '#==' do
+    context 'with members' do
+      let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+      context 'same class and members' do
+        subject { struct_class.new(a: 42, b: 43) == struct_class.new(a: 42, b: 43) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'same class and different members' do
+        subject { struct_class.new(a: 42, b: 43) == struct_class.new(a: 42, b: 0) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'different class and same members' do
+        subject { struct_class.new(a: 42, b: 43) == struct_class_1.new(a: 42, b: 43) }
+
+        let(:struct_class_1) { described_class.with_attributes(:a, :b) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'different class and different members' do
+        subject { struct_class.new(a: 42, b: 43) == struct_class.new(a: 42, b: 0) }
+
+        let(:struct_class_1) { described_class.with_attributes(:a, :b) }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+
+  describe '#members' do
+    let(:struct) { struct_class.new(b: 43, a: 42) }
+    let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+    it 'returns members in the order they defined' do
+      expect(struct.members).to eq(%i[a b])
+    end
+
+    it 'is immutable' do
+      expect { struct.members << :c }.not_to change { struct.members }.from(%i[a b])
+    end
+  end
+
+  describe '#to_a' do
+    let(:struct) { struct_class.new(b: 43, a: 42) }
+    let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+    it 'returns members values in the order they defined' do
+      expect(struct.to_a).to eq([42, 43])
+    end
+
+    it 'is immutable' do
+      expect { struct.to_a << 44 }.not_to change { struct.to_a }.from([42, 43])
+    end
+  end
+
+  describe '#to_h' do
+    let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+    context 'without block' do
+      let(:struct) { struct_class.new(b: 43, a: 42) }
+
+      it 'returns a Hash containing the names and values for the structs members' do
+        expect(struct.to_h).to eq(a: 42, b: 43)
+      end
+
+      it 'is immutable' do
+        expect { struct.to_h.merge(c: 44) }.not_to change { struct.to_h }.from(a: 42, b: 43)
+      end
+    end
+
+    context 'with block' do
+      subject do
+        struct.to_h do |key, value|
+          [key.upcase, value / 2]
+        end
+      end
+      let(:struct) { struct_class.new(b: 2, a: 4) }
+
+      it 'returns a Hash containing the names and values for the structs members' do
+        is_expected.to eq(A: 2, B: 1)
+      end
+    end
+  end
+
+  describe '#copy' do
+    let(:struct_class) { described_class.with_attributes(:a, :b) }
+    let(:struct) { struct_class.new(b: 43, a: 42) }
+
+    context 'attributes given' do
+      subject { struct.copy(b: 44) }
+
+      it { is_expected.to eq(struct_class.new(a: 42, b: 44)) }
+    end
+
+    context 'string attributes' do
+      subject { -> { struct.copy('a' => 44) } }
+
+      it { is_expected.to raise_error(ArgumentError, 'wrong number of arguments (given 1, expected 0)') }
+    end
+
+    context 'no attributes given' do
+      subject { struct.copy == struct }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe '#inspect' do
+    subject { StrInspect.new(a: 2, b: nil).inspect }
+    StrInspect = Fear::Struct.with_attributes(:a, :b)
+
+    it { is_expected.to eq('<#Fear::Struct StrInspect a=2, b=nil>') }
+  end
+
+  describe '#inspect' do
+    subject { StrToS.new(a: 2, b: nil).inspect }
+    StrToS = Fear::Struct.with_attributes(:a, :b)
+
+    it { is_expected.to eq('<#Fear::Struct StrToS a=2, b=nil>') }
+  end
+
+  context 'extract' do
+    Str = Fear::Struct.with_attributes(:a, :b)
+    let(:struct) { Str.new(b: 43, a: 42) }
+
+    context 'Fear::Struct subclass' do
+      context 'match by one member' do
+        subject do
+          proc do |effect|
+            struct.match do |m|
+              m.xcase('Str(a, 43)', &effect)
+            end
+          end
+        end
+
+        it { is_expected.to yield_with_args(a: 42) }
+      end
+
+      context 'does not match' do
+        subject do
+          proc do |effect|
+            struct.match do |m|
+              m.xcase('Str(_, 40)', &effect)
+              m.else {}
+            end
+          end
+        end
+
+        it { is_expected.not_to yield_control }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Structs are like regular classes and good for modeling immutable data.

A minimal struct requires just a list of attributes:

    User = Fear::Struct.with_attributes(:id, :email, :admin)
    john = User.new(id: 2, email: 'john@example.com', admin: false)

    john.email #=> 'john@example.com'

Instead of `.with_attributes` factory method you can use classic inheritance:

    class User < Fear::Struct
      attribute :id
      attribute :email
      attribute :admin
    end

Since structs are immutable, you are not allowed to reassign their attributes

    john.email = ''john.doe@example.com'' #=> raises NoMethodError

Two structs of the same type with the same attributes are equal

    john1 = User.new(id: 2, email: 'john@example.com', admin: false)
    john2 = User.new(id: 2, admin: false, email: 'john@example.com')
    john1 == john2 #=> true

You can create a shallow copy of a +Struct+ by using copy method optionally changing its attributes.

    john = User.new(id: 2, email: 'john@example.com', admin: false)
    admin_john = john.copy(admin: true)

    john.admin #=> false
    admin_john.admin #=> true

It's possible to match against struct attributes. The following example extracts email from
user only if user is admin

    john = User.new(id: 2, email: 'john@example.com', admin: false)
    john.match |m|
      m.xcase('Fear::Struct(_, email, true)') do |email|
        email
      end
    end

Note, parameters got extracted in order they was defined.
