### PR TITLE
Implement Option#zip

### DIFF
--- a/lib/fear/none.rb
+++ b/lib/fear/none.rb
@@ -59,6 +59,16 @@ module Fear
     def ===(other)
       self == other
     end
+
+    # @param other [Fear::Option]
+    # @return [Fear::Option]
+    def zip(other)
+      if other.is_a?(Option)
+        Fear.none
+      else
+        raise TypeError, "can't zip with #{other.class}"
+      end
+    end
   end
 
   private_constant(:NoneClass)

--- a/lib/fear/option.rb
+++ b/lib/fear/option.rb
@@ -153,6 +153,16 @@ module Fear
   #       m.else { 'error '}
   #     end
   #
+  # @!method zip(other)
+  #   @param other [Fear::Option]
+  #   @return [Fear::Option] a +Fear::Some+ formed from this option and another option by
+  #     combining the corresponding elements in an array.
+  #
+  #   @example
+  #     Fear.some("foo").zip(Fear.some("bar")) #=> Fear.some(["foo", "bar"])
+  #     Fear.some("foo").zip(Fear.none) #=> Fear.none
+  #     Fear.none.zip(Fear.some("bar")) #=> Fear.none
+  #
   # @see https://github.com/scala/scala/blob/2.11.x/src/library/scala/Option.scala
   #
   module Option

--- a/lib/fear/some.rb
+++ b/lib/fear/some.rb
@@ -67,5 +67,15 @@ module Fear
 
     # @return [String]
     alias to_s inspect
+
+    # @param other [Fear::Option]
+    # @return [Fear::Option]
+    def zip(other)
+      if other.is_a?(Option)
+        other.map { |x| [value, x].freeze }
+      else
+        raise TypeError, "can't zip with #{other.class}"
+      end
+    end
   end
 end

--- a/spec/fear/option_spec.rb
+++ b/spec/fear/option_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Fear::Option do
+  describe "#zip" do
+    subject { left.zip(right) }
+
+    context "some with some" do
+      let(:left) { Fear.some(42) }
+      let(:right) { Fear.some(664) }
+
+      it { is_expected.to eq(Fear.some([42, 664])) }
+    end
+
+    context "some with none" do
+      let(:left) { Fear.some(42) }
+      let(:right) { Fear.none }
+
+      it { is_expected.to eq(Fear.none) }
+    end
+
+    context "none with some" do
+      let(:left) { Fear.none }
+      let(:right) { Fear.some(42) }
+
+      it { is_expected.to eq(Fear.none) }
+    end
+
+    context "none with none" do
+      let(:left) { Fear.none }
+      let(:right) { Fear.none }
+
+      it { is_expected.to eq(Fear.none) }
+    end
+  end
+end


### PR DESCRIPTION
`option.zip(option)` returns a `Some` formed from this option and another option by combining the corresponding elements in an array.

```ruby
     Fear.some("foo").zip(Fear.some("bar")) #=> Fear.some(["foo", "bar"])
     Fear.some("foo").zip(Fear.none) #=> Fear.none
     Fear.none.zip(Fear.some("bar")) #=> Fear.none
```