### PR TITLE
Implement pattern matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,6 @@ inherit_gem:
   ruby_coding_standard: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - vendor/**/*

--- a/README.md
+++ b/README.md
@@ -1198,7 +1198,7 @@ matcher.(Fear.some(40)) #=> 'Nope'
 #### Under the hood 
 
 Pattern matcher is a combination of partial functions wrapped into nice DSL. Every partial function 
-defined on domain described with guard.
+defined on domain described with a guard.
 
 ```ruby
 pf = Fear.case(Integer) { |x| x / 2 }
@@ -1258,6 +1258,55 @@ handle = handle_numbers.or_else(handle_strings)
 handle.(0) #=> 'zero'
 handle.(12) #=> 'bigger than ten'
 handle.('one') #=> 1
+```
+
+### Native pattern-matching 
+
+Starting from ruby 2.7 you can use native pattern matching capabilities:
+
+```ruby 
+case Fear.some(42)
+in Fear::Some(x)
+  x * 2
+in Fear::None 
+  'none'
+end #=> 84
+
+case Fear.some(41)
+in Fear::Some(x) if x.even?
+  x / 2
+in Fear::Some(x) if x.odd? && x > 0
+  x * 2
+in Fear::None
+  'none'
+end #=> 82
+
+case Fear.some(42)
+in Fear::Some(x) if x.odd?
+  x * 2 
+else 
+  'nothing'
+end #=> nothing
+```
+
+It's possible to pattern match against Fear::Either and Fear::Try as well:
+
+```ruby 
+case either 
+in Fear::Right(Integer | String => x)
+  "integer or string: #{x}"
+in Fear::Left(String => error_code) if error_code = :not_found 
+  'not found'
+end  
+```
+
+```ruby 
+case Fear.try { 10 / x } 
+in Fear::Failure(ZeroDivisionError)
+  # ..
+in Fear::Success(x) 
+  # ..
+end  
 ```
 
 ### Dry-Types integration

--- a/lib/fear/either.rb
+++ b/lib/fear/either.rb
@@ -275,6 +275,11 @@ module Fear
     # @return [String]
     alias to_s inspect
 
+    # @return [<any>]
+    def deconstruct
+      [value]
+    end
+
     class << self
       # Build pattern matcher to be used later, despite off
       # +Either#match+ method, id doesn't apply matcher immanently,

--- a/lib/fear/failure.rb
+++ b/lib/fear/failure.rb
@@ -105,5 +105,10 @@ module Fear
 
     # @return [String]
     alias to_s inspect
+
+    # @return [<StandardError>]
+    def deconstruct
+      [exception]
+    end
   end
 end

--- a/lib/fear/some.rb
+++ b/lib/fear/some.rb
@@ -90,5 +90,10 @@ module Fear
     def filter_map(&filter)
       map(&filter).select(&:itself)
     end
+
+    # @return [Array<any>]
+    def deconstruct
+      [get]
+    end
   end
 end

--- a/lib/fear/struct.rb
+++ b/lib/fear/struct.rb
@@ -234,5 +234,15 @@ module Fear
     private def _set_attribute(name, value)
       instance_variable_set(:"@#{name}", value)
     end
+
+    # @param keys [Hash, nil]
+    # @return [Hash]
+    def deconstruct_keys(keys)
+      if keys
+        to_h.slice(*(self.class.attributes & keys))
+      else
+        to_h
+      end
+    end
   end
 end

--- a/lib/fear/success.rb
+++ b/lib/fear/success.rb
@@ -107,5 +107,10 @@ module Fear
 
     # @return [String]
     alias to_s inspect
+
+    # @return [<any>]
+    def deconstruct
+      [value]
+    end
   end
 end

--- a/spec/fear/either_pattern_matching_spec.rb
+++ b/spec/fear/either_pattern_matching_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Fear::Either do
+  describe "pattern matching" do
+    subject do
+      case value
+      in Fear::Right[Integer => int]
+        "right of #{int}"
+      in Fear::Left[Integer => int]
+        "left of #{int}"
+      else
+        "something else"
+      end
+    end
+
+    context "when value is right of integer" do
+      let(:value) { Fear.right(42) }
+
+      it { is_expected.to eq("right of 42") }
+    end
+
+    context "when value is left of integer" do
+      let(:value) { Fear.left(42) }
+
+      it { is_expected.to eq("left of 42") }
+    end
+  end
+end

--- a/spec/fear/option_pattern_matching_spec.rb
+++ b/spec/fear/option_pattern_matching_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Fear::Option do
+  describe "pattern matching" do
+    subject do
+      case value
+      in Fear::Some(Integer => int)
+        "some of #{int}"
+      in Fear::None
+        "none"
+      else
+        "something else"
+      end
+    end
+
+    context "when value is some of integer" do
+      let(:value) { Fear.some(42) }
+
+      it { is_expected.to eq("some of 42") }
+    end
+
+    context "when value is none" do
+      let(:value) { Fear.none }
+
+      it { is_expected.to eq("none") }
+    end
+
+    context "when value is not some of integer" do
+      let(:value) { Fear.some("42") }
+
+      it { is_expected.to eq("something else") }
+    end
+  end
+end

--- a/spec/fear/try_pattern_matching_spec.rb
+++ b/spec/fear/try_pattern_matching_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Fear::Try do
+  describe "pattern matching" do
+    subject do
+      case value
+      in Fear::Success[Integer => int]
+        "success of #{int}"
+      in Fear::Failure[RuntimeError]
+        "runtime error"
+      else
+        "something else"
+      end
+    end
+
+    context "when value is success of integer" do
+      let(:value) { Fear.try { 42 } }
+
+      it { is_expected.to eq("success of 42") }
+    end
+
+    context "when value is failure runtime error" do
+      let(:value) { Fear.try { raise } }
+
+      it { is_expected.to eq("runtime error") }
+    end
+
+    context "when value is something else" do
+      let(:value) { Fear.try { raise StandardError } }
+
+      it { is_expected.to eq("something else") }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ require "date"
 require "fear/rspec"
 
 RSpec.configure do |config|
+  unless RUBY_VERSION >= "2.7"
+    config.exclude_pattern = "**/*pattern_matching_spec.rb"
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/struct_pattern_matching_spec.rb
+++ b/spec/struct_pattern_matching_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Fear::Struct do
+  describe "pattern matching" do
+    subject do
+      case struct
+      in Fear::Struct(a: 42)
+        "a = 42"
+      in Fear::Struct(a: 43, **rest)
+        "a = 43, #{rest}"
+      in Fear::Struct(a:)
+        "a = #{a}"
+      end
+    end
+
+    let(:struct_class) { described_class.with_attributes(:a, :b) }
+
+    context "when match single value" do
+      let(:struct) { struct_class.new(b: 43, a: 42) }
+
+      it { is_expected.to eq("a = 42") }
+    end
+
+    context "when match single value and capture the rest" do
+      let(:struct) { struct_class.new(b: 42, a: 43) }
+
+      it { is_expected.to eq("a = 43, {:b=>42}") }
+    end
+
+    context "when capture a value" do
+      let(:struct) { struct_class.new(b: 45, a: 44) }
+
+      it { is_expected.to eq("a = 44") }
+    end
+  end
+end


### PR DESCRIPTION
Starting from ruby 2.7 you can use native pattern matching capabilities:

```ruby
case Fear.some(42)
in Fear::Some(x)
  x * 2
in Fear::None
  "none"
end #=> 84

case Fear.some(41)
in Fear::Some(x) if x.even?
  x / 2
in Fear::Some(x) if x.odd? && x > 0
  x * 2
in Fear::None
  "none"
end #=> 82

case Fear.some(42)
in Fear::Some(x) if x.odd?
  x * 2
else
  'nothing'
end #=> nothing
```

It's possible to pattern match against Fear::Either and Fear::Try as well:

```ruby
case either
in Fear::Right(Integer | String => x)
  "integer or string: #{x}"
in Fear::Left(String => error_code) if error_code = :not_found
  'not found'
end
```

```ruby
case Fear.try { 10 / x }
in Fear::Failure(ZeroDivisionError)
  # ..
in Fear::Success(x)
  # ..
end
```