### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.x 
+## 1.2.0
 
 * Implement `Fear::Option#zip` and `Fear::Future#zip` with block argument ([@bolshakov][]) 
 * Drop ruby 2.4.x support, test against ruby 2.7.x ([@bolshakov][])

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in functional.gemspec
 gemspec
 
-# gem 'codeclimate-test-reporter', group: :test, require: nil
-
 gem "irb"
 gem "qo", github: "baweaver/qo"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    fear (1.1.0)
+    fear (1.2.0)
       lru_redux
       treetop
 

--- a/fear.gemspec
+++ b/fear.gemspec
@@ -20,12 +20,6 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^spec\/})
   spec.require_paths = ["lib"]
 
-  spec.post_install_message = <<-MSG
-    Fear v0.11.0 introduces backwards-incompatible changes.
-    Please see https://github.com/bolshakov/fear/blob/master/CHANGELOG.md#0110 for details.
-    Successfully installed fear-#{Fear::VERSION}
-  MSG
-
   spec.add_runtime_dependency "lru_redux"
   spec.add_runtime_dependency "treetop"
 

--- a/lib/fear/version.rb
+++ b/lib/fear/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Fear
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
   public_constant :VERSION
 end


### PR DESCRIPTION
# Fear::Future#zip

Now you can call `Future#zip` with block argument which maps result

```ruby
this = Fear.future { 1 }
that = Fear.future { 2 }
this.zip(that) { |x, y| x + y } #=> Fear.success(3)
```

# Fear::Option#zip

```ruby
Fear.some("foo").zip(Fear.some("bar")) #=> Fear.some(["foo", "bar"])
Fear.some("foo").zip(Fear.some("bar")) { |x, y| x + y } #=> Fear.some("foobar")
Fear.some("foo").zip(Fear.none) #=> Fear.none
Fear.none.zip(Fear.some("bar")) #=> Fear.none
```

# Fear::Option#filter_map 

Returns a new `Some` of truthy results (everything except `false` or `nil`) or +None+ otherwise.

```ruby 
Fear.some(42).filter_map { |v| v/2 if v.even? } #=> Fear.some(21)
Fear.some(42).filter_map { |v| v/2 if v.odd? } #=> Fear.none
Fear.some(42).filter_map { |v| false } #=> Fear.none
Fear.none.filter_map { |v| v/2 }   #=> Fear.none
```

# Dry-Types and Dry-Struct integration

```ruby
require 'dry-types'
require 'dry/types/fear'

Dry::Types.load_extensions(:fear_option)

module Types
  include Dry.Types()
end
```

Append `.option` to a type name to return `Fear::Option` of object:

```ruby
Types::Option::Strict::Integer[nil] 
#=> Fear.none
Types::Option::Coercible::String[nil] 
#=> Fear.none
Types::Option::Strict::Integer[123] 
#=> Fear.some(123)
Types::Option::Strict::String[123]
#=> Fear.some(123)
Types::Option::Coercible::Float['12.3'] 
#=> Fear.some(12.3)
```

`Option` types can also accessed by calling `.option` on a regular type:

```ruby
Types::Strict::Integer.option # equivalent to Types::Option::Strict::Integer
```

You can define your own optional types:

```ruby
option_string = Types::Strict::String.option
option_string[nil]
# => Fear.none
option_string[nil].map(&:upcase)
# => Fear.none
option_string['something']
# => Fear.some('something')
option_string['something'].map(&:upcase)
# => Fear.some('SOMETHING')
option_string['something'].map(&:upcase).get_or_else { 'NOTHING' }
# => "SOMETHING"
```

You can use it with [dry-struct](https://dry-rb.org/gems/dry-struct/1.0/) as well:

```ruby
class User < Dry::Struct
  attribute :name, Types::Coercible::String
  attribute :age,  Types::Coercible::Integer.option
end

user = User.new(name: 'Bob', age: nil)
user.name #=> "Bob"
user.age #=> Fear.none 

user = User.new(name: 'Bob', age: 42)
user.age #=> Fear.some(42) 
```

# Implement pattern matching for ruby >= 2.7

Pattern matching works for `Fear::Option`, `Fear::Either`, and `Fear::Try`:

```ruby 
case Fear.some(41)
in Fear::Some(x) if x.even?
  x / 2
in Fear::Some(x) if x.odd? && x > 0
  x * 2
in Fear::None
  'none'
end #=> 82
```

`Fear.xcase` is deprecated and will be removed in fear 2.0.