### PR TITLE
Feature | Add non-emptiness check method

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ Fear.some(42).empty? #=> false
 Fear.none.empty?   #=> true
 ```
 
+#### Option#present?
+
+Returns `false` if the `Option` is `None`, `true` otherwise.
+
+```ruby
+Fear.some(42).present? #=> true
+Fear.none.present?   #=> false
+```
+
 #### Option#zip
 
 Returns a `Fear::Some` formed from this Option and another Option by combining the corresponding elements in a pair. 

--- a/lib/fear/none.rb
+++ b/lib/fear/none.rb
@@ -22,6 +22,11 @@ module Fear
       true
     end
 
+    # @return [false]
+    def present?
+      false
+    end
+
     # @return [None]
     def select(*)
       self

--- a/lib/fear/some.rb
+++ b/lib/fear/some.rb
@@ -28,6 +28,11 @@ module Fear
       false
     end
 
+    # @return [true]
+    def present?
+      true
+    end
+
     # @return [Option]
     def select
       if yield(value)

--- a/spec/fear/none_spec.rb
+++ b/spec/fear/none_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Fear::None do
     it { is_expected.to eq(true) }
   end
 
+  describe "#present?" do
+    subject { none.present? }
+    it { is_expected.to be_falsey }
+  end
+
   describe "#select" do
     subject { none.select { |value| value > 42 } }
 

--- a/spec/fear/some_spec.rb
+++ b/spec/fear/some_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe Fear::Some do
     it { is_expected.to eq(false) }
   end
 
+  describe "#present?" do
+    subject { some.present? }
+    it { is_expected.to be_truthy }
+  end
+
   describe "#match" do
     context "matched" do
       subject do


### PR DESCRIPTION
In the issue about adding [Shortcut for !monad.empty?](https://github.com/bolshakov/fear/issues/10) we decided to name this shortcut `#present?`

For `None` `#present?` will return `false` and for `Some` `#present?` will return `true`.

We can also add the `#blank?` alias for the `#empty?` method because some developers might expect the `#blank?` method if we have the `#present?` method here, but I'm not sure about this.