### PR TITLE
Release/2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 2.0.0 (not yet released)
+## 2.0.0
 
 * Added `Fear::Option#present?` and `Fear::Option#empty?` methods ([@Lokideos][])
-* Start testing against Ruby 3.0.0 ([@bolshakov][]) 
-* Minimal supported Ruby version is 2.6.0 ([@bolshakov][]) 
+* Start testing against Ruby 3.1.0 ([@bolshakov][]) 
+* Minimal supported Ruby version is 2.7.0 ([@bolshakov][]) 
 * Make future and promises compatible with Ruby 3.0 method syntax. ([@bolshakov][]) 
 * Get rid off autoload in favor of require. Autoload appeared to be not thread-safe. ([@bolshakov][]) 
 * All monads are shareable with Ractors ([@bolshakov][]) 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    fear (1.2.0)
+    fear (2.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/fear/version.rb
+++ b/lib/fear/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Fear
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
   public_constant :VERSION
 end


### PR DESCRIPTION
* Added `Fear::Option#present?` and `Fear::Option#empty?` methods ([@Lokideos][])
* Start testing against Ruby 3.1.0 ([@bolshakov][]) 
* Minimal supported Ruby version is 2.7.0 ([@bolshakov][]) 
* Make future and promises compatible with Ruby 3.0 method syntax. ([@bolshakov][]) 
* Get rid off autoload in favor of require. Autoload appeared to be not thread-safe. ([@bolshakov][]) 
* All monads are shareable with Ractors ([@bolshakov][]) 
* Drop pattern extraction support (`Fear.xcase`). ([@bolshakov][]) 
* Add top-level factory methods: `Fear::Some`, `Fear::Option`, `Fear::Right`, `Fear::Left` ([@bolshakov][]) 
  `Fear::Try`, `Fear::Success`, and `Fear::Failure`. ([@bolshakov][])

[@bolshakov]: https://github.com/bolshakov
[@Lokideos]: https://github.com/Lokideos