### PR TITLE
Add an alias 'apply' to the 'each' method

### DIFF
--- a/lib/fear/either/left_projection.rb
+++ b/lib/fear/either/left_projection.rb
@@ -83,6 +83,7 @@ module Fear
           either
         end
       end
+      alias apply each
 
       # Maps the block argument through +Fear::Left+.
       #

--- a/lib/fear/right_biased.rb
+++ b/lib/fear/right_biased.rb
@@ -70,6 +70,7 @@ module Fear
         yield(value)
         self
       end
+      alias apply each
 
       # Maps the value using given block.
       #
@@ -144,6 +145,7 @@ module Fear
       def each
         self
       end
+      alias apply each
 
       # Ignores the given block and return self.
       #


### PR DESCRIPTION
When we want to raise an exception because of Fear::Left in some part of a change the code below can be written: `Fear.left('error').swap.each {|e| raise(e)}.swap`.

I found two issues:
1) The 'each' method implies that an object is enumerable. So it may confuse developers.
2) Rubocop also thinks that an each method implies a look. So the code below causes the RuboCop::Cop::Lint::UnreachableLoop issue.

I suggest a solution to have an alias to the 'each' method. The 'apply' name looks suitable. So the code above would be changed to `Fear.left('error').swap.apply {|e| raise(e)}.swap`

What do you think?